### PR TITLE
Rename MAX_MDB_SIZE env var and --max-mdb-size option flag

### DIFF
--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -24,18 +24,6 @@ N/A
 
 - Rename `--max-mdb-size` to `--max-index-size`
 - Rename `MAX_MDB_SIZE` to `MAX_INDEX_SIZE`
-- Error handling at index creation should be iso with version 0.20.
-
-When I test the current version of meilisearch in 0.21, the http call on `POST /indexes/:index_uid/documents` is successful and an empty index is created whereas 0.20 returns an error on the API side and the index is not created.
-
-```
-{
-    "message": "Impossible to create index; heed error; MDB_MAP_FULL: Environment mapsize limit reached",
-    "errorCode": "index_creation_failed",
-    "errorType": "internal_error",
-    "errorLink": "https://docs.meilisearch.com/errors#index_creation_failed"
-}
-```
 
 ### V. Impact on Documentation
 

--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -25,9 +25,6 @@ N/A
  - Rename `--max-mdb-size` to `--max-index-size`
  - Rename `MAX_MDB_SIZE` to `MAX_INDEX_SIZE`
 
-The size entered must therefore be greater than or equal to the largest index of the search engine.
-
-The known limitation is that smaller indexes will take up a space equal to the larger index.
 
 ### V. Impact on Documentation
 

--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -1,16 +1,16 @@
-- Title: Rename MAX_MDB_SIZE  configuration variable
-- Start Date: 2021-
+- Title: Rename MAX_MDB_SIZE env var and --max-mdb-size option flag
+- Start Date: 2021-04-14
 - Specification PR: [#48](https://github.com/meilisearch/specifications/pull/48)
 - MeiliSearch Tracking-issues: [transplant/#206](https://github.com/meilisearch/transplant/issues/206)
 
 
-# Rename MAX_MDB_SIZE configuration variable
+# Rename MAX_MDB_SIZE env var and --max-mdb-size option flag
 
 ## 1. Functional Specification
 
 ### I. Summary
 
-This specification is written to rename the `MAX_MDB_SIZE` configuration variable.
+This specification is written to rename the `MAX_MDB_SIZE` environnement variable and `--max-mdb-size` option flag to `MAX_INDEX_SIZE` and `--max-index-size`.
 
 ### II. Motivation
 

--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -22,9 +22,20 @@ N/A
 
 ### IV. Explanation
 
- - Rename `--max-mdb-size` to `--max-index-size`
- - Rename `MAX_MDB_SIZE` to `MAX_INDEX_SIZE`
+- Rename `--max-mdb-size` to `--max-index-size`
+- Rename `MAX_MDB_SIZE` to `MAX_INDEX_SIZE`
+- Error handling at index creation should be iso with version 0.20.
 
+When I test the current version of meilisearch in 0.21, the http call on `POST /indexes/:index_uid/documents` is successful and an empty index is created whereas 0.20 returns an error on the API side and the index is not created.
+
+```
+{
+    "message": "Impossible to create index; heed error; MDB_MAP_FULL: Environment mapsize limit reached",
+    "errorCode": "index_creation_failed",
+    "errorType": "internal_error",
+    "errorLink": "https://docs.meilisearch.com/errors#index_creation_failed"
+}
+```
 
 ### V. Impact on Documentation
 

--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -1,7 +1,7 @@
 - Title: Rename MAX_MDB_SIZE  configuration variable
 - Start Date: 2021-
 - Specification PR: [#48](https://github.com/meilisearch/specifications/pull/48)
-- MeiliSearch Tracking-issues:
+- MeiliSearch Tracking-issues: [transplant/#206](https://github.com/meilisearch/transplant/issues/206)
 
 
 # Rename MAX_MDB_SIZE configuration variable

--- a/text/0048-rename-max-mdb-size-var.md
+++ b/text/0048-rename-max-mdb-size-var.md
@@ -1,0 +1,43 @@
+- Title: Rename MAX_MDB_SIZE  configuration variable
+- Start Date: 2021-
+- Specification PR: [#48](https://github.com/meilisearch/specifications/pull/48)
+- MeiliSearch Tracking-issues:
+
+
+# Rename MAX_MDB_SIZE configuration variable
+
+## 1. Functional Specification
+
+### I. Summary
+
+This specification is written to rename the `MAX_MDB_SIZE` configuration variable.
+
+### II. Motivation
+
+Since version 0.21 no longer has a main LMDB database for all indexes but one LMBD database per index, the concept of a `main` database no longer exists internally.
+
+
+### III. Additional Materials
+N/A
+
+### IV. Explanation
+
+ - Rename `--max-mdb-size` to `--max-index-size`
+ - Rename `MAX_MDB_SIZE` to `MAX_INDEX_SIZE`
+
+The size entered must therefore be greater than or equal to the largest index of the search engine.
+
+The known limitation is that smaller indexes will take up a space equal to the larger index.
+
+### V. Impact on Documentation
+
+- Update the [Max MDB Size documentation part](https://docs.meilisearch.com/reference/features/configuration.html#max-mdb-size).
+
+### VI. Impact on SDKs
+N/A
+
+## 2. Technical Aspects
+N/A
+
+## 3. Future Possibilities
+- Provide a way to set a custom size per index.


### PR DESCRIPTION
### I. Summary

This specification is written to rename the `MAX_MDB_SIZE` environnement variable and `--max-mdb-size` option flag to `MAX_INDEX_SIZE` and `--max-index-size`.

### II. Motivation

Since version 0.21 no longer has a main LMDB database for all indexes but one LMBD database per index, the concept of a `main` database no longer exists internally.