### PR TITLE
Geosearch

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -605,7 +605,11 @@ components:
       schema:
         type: string
         example: 'price:asc'
-      description: Fields on which you want to sort the results.
+      description: |
+        Fields on which you want to sort the results.
+
+        > info
+        > _geoPoint({lat}, {long}) built-in sort rule can be used to sort documents around a geo point.
     filter:
       name: filter
       in: query
@@ -1684,6 +1688,9 @@ paths:
       summary: Update sortable attributes
       description: |
         Update the list of [sortableAttributes](https://docs.meilisearch.com/reference/features/sortableAttributes.html) of an index.
+
+        > info
+        > In order to enable sorting capabilities on geographic data, the `_geo` field must be added as a sortableAttribute.
       tags:
         - Settings
       security:

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -124,6 +124,7 @@ components:
                 length: 5
               - start: 155
                 length: 5
+      description: ''
       properties:
         _formatted:
           type: object
@@ -140,7 +141,9 @@ components:
             - string
             - number
           description: Retrieve attributes of the document. `attributesToRetrieve` controls these fields.
-      description: ''
+        _geoDistance:
+          type: number
+          description: 'Using _geoPoint({lat}, {lng}) built-in sort rule at search leads the engine to return a _geoDistance within the search results. This field represents the distance in meters of the document from the specified _geoPoint.'
     documentId:
       oneOf:
         - type: number
@@ -155,6 +158,9 @@ components:
         - Nested Array: `["something > 1", "genres=comedy", ["genres=horror", "title=batman"]]`
         - String: `"something > 1 AND genres=comedy AND (genres=horror OR title=batman)"`
         - Mixed: `["something > 1 AND genres=comedy", "genres=horror OR title=batman"]`
+
+        > info
+        > _geoRadius({lat}, {lng}, {distance_in_meters}) built-in filter rule can be used to filter documents within a geo circle.
 
         > warn
         > Attribute(s) used in `filter` should be declared as filterable attributes. See [Filtering and Faceted Search](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html).
@@ -615,6 +621,9 @@ components:
         - String: `something > 1 AND genres=comedy AND (genres=horror OR title=batman)`
         - Mixed: `["something > 1 AND genres=comedy", "genres=horror OR title=batman"]`
 
+        > info
+        > _geoRadius({lat}, {lng}, {distance_in_meters}) built-in filter rule can be used to filter documents within a geo circle.
+
         > warn
         > Attribute(s) used in `filter` should be declared as filterable attributes. See [Filtering and Faceted Search](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html).
   responses:
@@ -668,6 +677,13 @@ components:
       type: apiKey
       in: header
       name: X-Meili-API-Key
+      description: |-
+        An API key is a token that you provide when making API calls. Include the token in a header parameter called `X-Meili-API-Key`.
+
+        Example: `X-Meili-API-Key: 123`
+
+        > info
+        > test
   examples: {}
 tags:
   - name: Indexes
@@ -1022,8 +1038,13 @@ paths:
     post:
       operationId: indexes.documents.create
       summary: Add or replace documents
+<<<<<<< HEAD
       description: |
         Add a list of [documents](https://docs.meilisearch.com/learn/core_concepts/documents.html) or replace them if they already exist.
+=======
+      description: |-
+        Add a list of [documents](/learn/core_concepts/documents.html) or replace them if they already exist.
+>>>>>>> Add description in OpenApi
 
         If you send an already existing document (same [id](https://docs.meilisearch.com/learn/core_concepts/documents.html#primary-key)) the whole existing document will be overwritten by the new document. Fields previously in the document not present in the new document are removed.
 
@@ -1031,6 +1052,9 @@ paths:
 
         > info
         > If the provided index does not exist, it will be created.
+
+        > info
+        > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
       tags:
         - Documents
       security:
@@ -1042,6 +1066,7 @@ paths:
             schema:
               type: array
               items: null
+            examples: {}
       responses:
         '202':
           $ref: '#/components/responses/202'
@@ -1052,7 +1077,7 @@ paths:
     put:
       operationId: indexes.documents.upsert
       summary: Add or update documents
-      description: |
+      description: |-
         Add a list of documents or update them if they already exist.
 
         If you send an already existing document (same [id](https://docs.meilisearch.com/learn/core_concepts/documents.html#primary-key)) the old document will be only partially updated according to the fields of the new document. Thus, any fields not present in the new document are kept and remained unchanged.
@@ -1061,6 +1086,9 @@ paths:
 
         > info
         > If the provided index does not exist, it will be created.
+
+        > info
+        > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
       tags:
         - Documents
       security:
@@ -1873,6 +1901,9 @@ paths:
       summary: Update Filterable Attributes
       description: |
         Update the [filterable attributes](https://docs.meilisearch.com/reference/features/settings.html#filterable-attributes) of an index.
+
+        > info
+        > In order to enable filtering capabilities on geographic data, the `_geo` field must be added as a filterableAttribute.
 
         > info
         > If the provided index does not exist, it will be created.

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1038,13 +1038,8 @@ paths:
     post:
       operationId: indexes.documents.create
       summary: Add or replace documents
-<<<<<<< HEAD
       description: |
         Add a list of [documents](https://docs.meilisearch.com/learn/core_concepts/documents.html) or replace them if they already exist.
-=======
-      description: |-
-        Add a list of [documents](/learn/core_concepts/documents.html) or replace them if they already exist.
->>>>>>> Add description in OpenApi
 
         If you send an already existing document (same [id](https://docs.meilisearch.com/learn/core_concepts/documents.html#primary-key)) the whole existing document will be overwritten by the new document. Fields previously in the document not present in the new document are removed.
 

--- a/text/0055-sort.md
+++ b/text/0055-sort.md
@@ -2,7 +2,6 @@
 - Start Date: 2021-07-20
 - Specification PR: [#55](https://github.com/meilisearch/specifications/pull/55)
 - Discovery Issue: [#43](https://github.com/meilisearch/product/issues/43)
-- MeiliSearch Tracking-issues:
 
 # Sort
 
@@ -148,6 +147,10 @@ Request body
 #### **As an End-User, I want to specify a `sort` parameter at search time so that I can sort search result in ascending/descending order from document attributes, whether they are `numeric` or `string`.**
 
 - Introduce a `sort` parameter on GET/POST `/search` methods.
+
+> 💡 In the case where an attribute is specified as a sort criterion at search time and if this attribute is of a different type between several documents, the numeric type will always be favored first by the engine. This means that documents with numeric values for this attribute will be sorted before those with string values. This can lead to awkward sorting behavior, so the user should make sure to have the same type on the attribute he wants to sort on for all these documents.
+
+> 💡 In the case where an attribute is specified as a sort criterion at search time and does not exist on a document, the document will be placed at the end of the ranking rule sort.
 
 **GET Search /indexes/{indexUid}/search**
 
@@ -408,6 +411,8 @@ Note that if I change the `sort` parameter's value order, it changes the inner e
 - Add `sort` query/request parameter on `/search` resource. Support `string` and `number`. `string` can be sorted in lexicographical order.
 - Change custom ranking rule format. e.g. `asc(price)` become `price:asc`
 - Add a new error `invalid_sort` similar to `invalid_filter`.
+- The numeric type is preferred to the string type by the `sort` ranking rule. If an attribute has different types among the documents, those containing a numeric value will be placed before the documents containing a string value type.
+- A document not containing an attribute requested in the `sort` parameter will be placed last during the tie-breaking of the `sort` ranking-rule.
 
 ## 2. Technical details
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -1,0 +1,24 @@
+- Title: Geo-search
+- Start Date: 2021-08-02
+- Specification PR: [#59](https://github.com/meilisearch/specifications/pull/59)
+- MeiliSearch Tracking-issues:
+
+# Geo-search
+
+## 1. Functional Specification
+
+### I. Summary
+
+The purpose of this specification is to add the **geo-search** first iteration feature to filter and sort the search results as an end-user. This first iteration allows to filter the documents in a geo circle shape and sort them around a geographical point.
+
+#### Summary Key points
+
+- Documents MUST have a `_geo` reserved object to be geo-searchable.
+- Filter documents by a given geo radius. It is possible to cumulate several geo-search filters within the `filter` field. `_geoRadius({lat}, {lng}, {distance_in_meters})`.
+- Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
+- It is possible to filter and/or sort by geographical criteria of the user's choice.
+- There is no `geo` ranking rule that can be manipulated by the user. This one is integrated in the ranking rule `sort` by default.
+
+### II. Motivation
+
+According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using `geohash` to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -9,7 +9,7 @@
 
 ### I. Summary
 
-The purpose of this specification is to add the **geo-search** first iteration feature to filter and sort the search results as an end-user. This first iteration allows to filter the documents in a geo circle shape and sort them around a geographical point.
+The purpose of this specification is to add a first iteration of the **geo-search** feature to give geo-filtering and geo-sorting capabilities at search time.
 
 #### Summary Key points
 
@@ -21,4 +21,10 @@ The purpose of this specification is to add the **geo-search** first iteration f
 
 ### II. Motivation
 
-According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using `geohash` to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
+According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
+
+## 3. Future Possibilities
+
+- Handling array of geo points in the document object.
+- Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geo-hash etc..
+- Filter documents in polygon and bounding-box.

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -114,8 +114,6 @@ csv format example
 ```
 
 > 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. An `invalid_request_error` description is given in the `update` object.
->
-> The `_geo` field does not need to be referred in `filterableAttributes` and `sortableAttributes` by the developer.
 
 ---
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -169,7 +169,7 @@ csv format example
 - Not required
 
 Following the [`sort` specification feature](https://github.com/meilisearch/specifications/pull/55):
-> The `_geo` field has to be set in `sortableAttributes` setting by the developer to activate geo fsorting capabilities at search.
+> The `_geo` field has to be set in `sortableAttributes` setting by the developer to activate geo sorting capabilities at search.
 >
 >There is no `geo` ranking rule as such. It is in fact within the `sort` ranking rule in an obfuscated way.
 >
@@ -203,7 +203,7 @@ Following the [`sort` specification feature](https://github.com/meilisearch/spec
 - Type: int
 - Not required
 
-> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. So if the end-user filter documents using a `_geoRadius` built-in filter without sorting them around a `_geoPoint`, this field `_geoDistance` will not appear in the search response.
+> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. So if the end-user filters documents using a `_geoRadius` built-in filter without sorting them around a `_geoPoint`, this field `_geoDistance` will not appear in the search response.
 
 ### IV. Finalized Key Changes
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -1,6 +1,7 @@
 - Title: Geo-search
 - Start Date: 2021-08-02
 - Specification PR: [#59](https://github.com/meilisearch/specifications/pull/59)
+- Discovery Issue: [#42](https://github.com/meilisearch/product/issues/42)
 - MeiliSearch Tracking-issues:
 
 # Geo-search
@@ -14,7 +15,7 @@ The purpose of this specification is to add a first iteration of the **geo-searc
 #### Summary Key points
 
 - Documents MUST have a `_geo` reserved object to be geo-searchable.
-- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geo-search filters within the `filter` field. .
+- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geo-search filters within the `filter` field.
 - Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
 - It is possible to filter and/or sort by geographical criteria of the user's choice.
 - There is no `geo` ranking rule that can be manipulated by the user. This one is automatically integrated in the ranking rule `sort` by default and activated by sorting using the `_geoPoint({lat}, {lng})` built-in sort rule.
@@ -40,14 +41,14 @@ According to our user feedback, the lack of a geo-search feature is mentioned as
 - Format: `{lat:float, lng:float}`
 - Not required
 
-💡 if `_geo` is found in the document payload, `lat` and `lng` are required.
-💡 `lat` and `lng` must be of float value.
+> 💡 if `_geo` is found in the document payload, `lat` and `lng` are required.
+> 💡 `lat` and `lng` must be of float value.
 
 ##### **CSV Format**
 
 Following the format already defined in the https://github.com/meilisearch/specifications/pull/28/files specification for document indexing from a CSV format. A reserved column `_geo` can be added to specify the geographical coordinates of a document.
 
-e.g.
+csv format example
 ```
 "id:number","label","brand","_geo"
 "1","F40","Ferrari","48.862725,2.287592"
@@ -110,7 +111,13 @@ e.g.
 }
 ```
 
-### **As a end-user, I want to filter documents by a geo radius.**
+> 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. An `invalid_request_error` description is given in the `update` object.
+>
+> The `_geo` field does not need to be referred in `filterableAttributes` and `sortableAttributes` by the developer.
+
+---
+
+### **As an end-user, I want to filter documents within a geo radius.**
 
 - Introduce a `_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule  to `filter` documents in a geo radius.shape.
 
@@ -119,6 +126,8 @@ e.g.
 - Name: `_geoRadius`
 - Signature: ({lat:float}:required, {lng:float}:required, {distance_in_meters:int}:required)
 - Not required
+
+>  The `_geo` field does not need to be referred in `sortableAttributes` by the developer.
 
 #### GET Search `/indexes/{indexUid}/search`
 
@@ -136,7 +145,9 @@ e.g.
 
 > 🔴 Specifying parameters that do not conform to the `_geoRadius` signature causes the API to return an `invalid_filter` error. The error message should indicate how `_geoRadius` should be used. See `_geoRadius` built-in filter rule definition part.
 
-### **As a end-user, I want to sort documents around a geo point.**
+---
+
+### **As an end-user, I want to sort documents around a geo point.**
 
 - Introduce a `_geoPoint({lat}, {lng})` function parameter to `sort` documents around a central point.
 
@@ -147,9 +158,11 @@ e.g.
 - Not required
 
 Following the [`sort` specification feature](https://github.com/meilisearch/specifications/pull/55):
-- The `_geo` field does not need to be referred to as `sortableAttributes` by the developer.
-- There is no `geo` ranking rule as such. It is in fact within the `sort` ranking rule in an obfuscated way.
-- `_geoRadius` built-in sort rule can sort documents in ascending or descending order.
+>The `_geo` field does not need to be referred in `sortableAttributes` by the developer.
+>
+>There is no `geo` ranking rule as such. It is in fact within the `sort` ranking rule in an obfuscated way.
+>
+>`_geoRadius` built-in sort rule can sort documents in ascending or descending order.
 
 #### GET Search `/indexes/{indexUid}/search`
 
@@ -166,26 +179,32 @@ Following the [`sort` specification feature](https://github.com/meilisearch/spec
 ```
 > 🔴 Specifying parameters that do not conform to the `_geoPoint` signature causes the API to return an `invalid_sort` error. The error message should indicate how `_geoPoint` should be used. See `_geoRadius` built-in sort rule definition part.
 
-### **As a end-user, I want to know the document distance when I am sorting around a geo point.**
+---
+
+### **As an end-user, I want to know the document distance when I am sorting around a geo point.**
 
 - Introduce a `_geoDistance` parameter to the search result `hit` object.
 
 **`_geoDistance` field definition**
 
 - Name: `_geoDistance`
-- Description: Return document distance from a `_geoPoint` in meters.
+- Description: Return document distance when the end-user sorts documents from a `_geoPoint` in meters.
 - Type: int
 - Not required
 
-> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. Filtering documents by a `_geoRadius` does not calculate and display the `_geoDistance` field within the search results.
-
+> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`.
 
 ### IV. Finalized Key Changes
+
+### V. Measuring
+
+-
+-
 
 ## 2. Technical Aspects
 
 ## 3. Future Possibilities
 
+- Add built-in filter to filter documents within `polygon` and `bounding-box`.
 - Handling array of geo points in the document object.
 - Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geo-hash etc..
-- Filter documents in polygon and bounding-box.

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -14,14 +14,175 @@ The purpose of this specification is to add a first iteration of the **geo-searc
 #### Summary Key points
 
 - Documents MUST have a `_geo` reserved object to be geo-searchable.
-- Filter documents by a given geo radius. It is possible to cumulate several geo-search filters within the `filter` field. `_geoRadius({lat}, {lng}, {distance_in_meters})`.
+- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geo-search filters within the `filter` field. .
 - Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
 - It is possible to filter and/or sort by geographical criteria of the user's choice.
-- There is no `geo` ranking rule that can be manipulated by the user. This one is integrated in the ranking rule `sort` by default.
+- There is no `geo` ranking rule that can be manipulated by the user. This one is automatically integrated in the ranking rule `sort` by default and activated by sorting using the `_geoPoint({lat}, {lng})` built-in sort rule.
+- Using `_geoPoint({lat}, {lng})` in the `sort` parameter at search leads the engine to return a `_geoDistance` within the search results. This field represents the distance in meters of the document from the specified `_geoPoint`.
 
 ### II. Motivation
 
 According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
+
+### III. Technical Explanations
+
+#### **As a developer, I want to add geo-spatial coordinates to a document so that the document can be geo-searchable.**
+
+- Introduce a reserved field `_geo` for documents to store geo spatial data from an **object** made of `lat` and `lng` fields for a **JSON format**.
+- Introduce a reserved column `_geo` for documents to store geo spatial data from a **string** made of `lat,lng` for a **CSV format**.
+
+##### **JSON Format**
+
+**`_geo` field definition**
+
+- Name: `_geo`
+- Type: Object
+- Format: `{lat:float, lng:float}`
+- Not required
+
+💡 if `_geo` is found in the document payload, `lat` and `lng` are required.
+💡 `lat` and `lng` must be of float value.
+
+##### **CSV Format**
+
+Following the format already defined in the https://github.com/meilisearch/specifications/pull/28/files specification for document indexing from a CSV format. A reserved column `_geo` can be added to specify the geographical coordinates of a document.
+
+e.g.
+```
+"id:number","label","brand","_geo"
+"1","F40","Ferrari","48.862725,2.287592"
+```
+
+**`_geo` column definition**
+
+- Name: `_geo`
+- Type: String
+- Format: `"lat:float,lng:float"`
+- Not required
+
+#### POST Add or replace documents `/indexes/{indexUid}/documents`
+
+##### Request body
+```
+[
+    {
+        "id": 1,
+        "label": "F40",
+        "brand": "Ferrari",
+        "_geo": {
+            "lat": 48.862725,
+            "lng": 2.287592
+        }
+    }
+]
+```
+
+##### 202 Accepted - Response body
+
+```
+{
+    "updateId": 1
+}
+```
+
+#### PUT Add or replace documents `/indexes/{indexUid}/documents`
+
+##### Request body
+```
+[
+    {
+        "id": 1,
+        "brand": "F40 LM",
+        "brand": "Ferrari",
+        "_geo": {
+            "lat": 48.862725,
+            "lng": 2.287592
+        }
+    }
+]
+```
+
+##### 202 Accepted - Response body
+
+```
+{
+    "updateId": 2
+}
+```
+
+### **As a end-user, I want to filter documents by a geo radius.**
+
+- Introduce a `_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule  to `filter` documents in a geo radius.shape.
+
+**`_geoRadius` built-in filter rule definition**
+
+- Name: `_geoRadius`
+- Signature: ({lat:float}:required, {lng:float}:required, {distance_in_meters:int}:required)
+- Not required
+
+#### GET Search `/indexes/{indexUid}/search`
+
+```
+...&filter="brand=Mercedes AND _geoRadius(48.862725, 2.287592, 2000)"`
+```
+
+#### POST Search `/indexes/{indexUid}/search`
+
+```
+{
+    "filter": ["brand = Ferrari", "_geoRadius(48.862725, 2.287592, 2000)"]
+}
+```
+
+> 🔴 Specifying parameters that do not conform to the `_geoRadius` signature causes the API to return an `invalid_filter` error. The error message should indicate how `_geoRadius` should be used. See `_geoRadius` built-in filter rule definition part.
+
+### **As a end-user, I want to sort documents around a geo point.**
+
+- Introduce a `_geoPoint({lat}, {lng})` function parameter to `sort` documents around a central point.
+
+**`_geoPoint` built-in sort rule definition**
+
+- Name: `_geoPoint`
+- Signature: ({lat:float}:required, {lng:float}:required)
+- Not required
+
+Following the [`sort` specification feature](https://github.com/meilisearch/specifications/pull/55):
+- The `_geo` field does not need to be referred to as `sortableAttributes` by the developer.
+- There is no `geo` ranking rule as such. It is in fact within the `sort` ranking rule in an obfuscated way.
+- `_geoRadius` built-in sort rule can sort documents in ascending or descending order.
+
+#### GET Search `/indexes/{indexUid}/search`
+
+```
+    ...&sort=_geoPoint({lat, lng}):asc,price:desc
+```
+
+#### POST Search `/indexes/{indexUid}/search`
+
+```
+{
+    "sort": "_geoPoint({lat, lng}):asc,price:desc"
+}
+```
+> 🔴 Specifying parameters that do not conform to the `_geoPoint` signature causes the API to return an `invalid_sort` error. The error message should indicate how `_geoPoint` should be used. See `_geoRadius` built-in sort rule definition part.
+
+### **As a end-user, I want to know the document distance when I am sorting around a geo point.**
+
+- Introduce a `_geoDistance` parameter to the search result `hit` object.
+
+**`_geoDistance` field definition**
+
+- Name: `_geoDistance`
+- Description: Return document distance from a `_geoPoint` in meters.
+- Type: int
+- Not required
+
+> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. Filtering documents by a `_geoRadius` does not calculate and display the `_geoDistance` field within the search results.
+
+
+### IV. Finalized Key Changes
+
+## 2. Technical Aspects
 
 ## 3. Future Possibilities
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -22,6 +22,7 @@ The purpose of this specification is to add a first iteration of the **geo-searc
 - `_geo` must be set as a sortable attribute to use geo sort capabilities.
 - There is no `geo` ranking rule that can be manipulated by the user. This one is automatically integrated in the ranking rule `sort` by default and activated by sorting using the `_geoPoint({lat}, {lng})` built-in sort rule.
 - Using `_geoPoint({lat}, {lng})` in the `sort` parameter at search leads the engine to return a `_geoDistance` within the search results. This field represents the distance in meters of the document from the specified `_geoPoint`.
+- Add an `invalid_geo_field` error.
 
 ### II. Motivation
 
@@ -113,7 +114,16 @@ csv format example
 }
 ```
 
-> 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. An `invalid_request_error` description is given in the `update` object.
+> 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. A new `invalid_geo_field` error is given in the `update` object.
+
+##### `invalid_geo_field` error
+
+| field     | value                                                                                                                |
+|-----------|----------------------------------------------------------------------------------------------------------------------|
+| message   | The _geo field is invalid.                                                                                           |
+| errorCode | invalid_geo_field                                                                                                    |
+| errorType | invalid_request_error                                                                                                |
+| errorLink | *Link to the dedicated error page. This page should give further links to indicate the expected JSON and CSV format* |
 
 ---
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -2,7 +2,6 @@
 - Start Date: 2021-08-02
 - Specification PR: [#59](https://github.com/meilisearch/specifications/pull/59)
 - Discovery Issue: [#42](https://github.com/meilisearch/product/issues/42)
-- MeiliSearch Tracking-issues:
 
 # Geosearch
 
@@ -116,14 +115,26 @@ csv format example
 
 > 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. A new `invalid_geo_field` error is given in the `update` object.
 
-##### `invalid_geo_field` error
+##### Errors Definition
 
-| field     | value                                                                                                                |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| message   | The _geo field is invalid.                                                                                           |
-| errorCode | invalid_geo_field                                                                                                    |
-| errorType | invalid_request_error                                                                                                |
-| errorLink | *Link to the dedicated error page. This page should give further links to indicate the expected JSON and CSV format* |
+## invalid_geo_field
+
+### Context
+
+This error occurs when the `_geo` field of a document payload is not valid.
+
+### Error Definition
+
+```json
+{
+    "message": "The _geo field is invalid. :syntaxErrorHelper.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+- The `:syntaxErrorHelper` is inferred when a syntax error is encountered.
 
 ---
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -1,21 +1,21 @@
-- Title: Geo-search
+- Title: Geosearch
 - Start Date: 2021-08-02
 - Specification PR: [#59](https://github.com/meilisearch/specifications/pull/59)
 - Discovery Issue: [#42](https://github.com/meilisearch/product/issues/42)
 - MeiliSearch Tracking-issues:
 
-# Geo-search
+# Geosearch
 
 ## 1. Functional Specification
 
 ### I. Summary
 
-The purpose of this specification is to add a first iteration of the **geo-search** feature to give geo-filtering and geo-sorting capabilities at search time.
+The purpose of this specification is to add a first iteration of the **geosearch** feature to give geo-filtering and geosorting capabilities at search time.
 
 #### Summary Key points
 
-- Documents MUST have a `_geo` reserved object to be geo-searchable.
-- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geo-search filters within the `filter` field.
+- Documents MUST have a `_geo` reserved object to be geosearchable.
+- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geosearch filters within the `filter` field.
 - Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
 - It is possible to filter and/or sort by geographical criteria of the user's choice.
 - `_geo` must be set as a filterable attribute to use geo filtering capabilities.
@@ -26,11 +26,11 @@ The purpose of this specification is to add a first iteration of the **geo-searc
 
 ### II. Motivation
 
-According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
+According to our user feedback, the lack of a geosearch feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geosearch capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geosearch documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
 
 ### III. Technical Explanations
 
-#### **As a developer, I want to add geo-spatial coordinates to a document so that the document can be geo-searchable.**
+#### **As a developer, I want to add geospatial coordinates to a document so that the document can be geosearchable.**
 
 - Introduce a reserved field `_geo` for documents to store geo spatial data from an **object** made of `lat` and `lng` fields for a **JSON format**.
 - Introduce a reserved column `_geo` for documents to store geo spatial data from a **string** made of `lat,lng` for a **CSV format**.
@@ -229,4 +229,4 @@ We may encounter technical difficulties to implement a descending order capabili
 
 - Add built-in filter to filter documents within `polygon` and `bounding-box`.
 - Handling array of geo points in the document object.
-- Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geo-hash etc..
+- Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geohash etc..


### PR DESCRIPTION
# I. Summary

The purpose of this specification is to add a first iteration of the **geo-search** feature to give geo-filtering and geo-sorting capabilities at search time. 

This first iteration allows to filter documents in a geo circle shape and to sort them around a geographical point.

## Summary Key Points

- Documents MUST have a `_geo` reserved object to be geo-searchable.
- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geo-search filters within the `filter` field.
- Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
- It is possible to filter and/or sort by geographical criteria of the user's choice.
- `_geo` must be set as a filterable attribute to use geo-filtering capabilities.
- `_geo` must be set as a sortable attribute to use geo-sorting capabilities.
- There is no `geo` ranking rule that can be manipulated by the user. This one is automatically integrated in the ranking rule `sort` by default and activated by using the `_geoPoint({lat}, {lng})` built-in sort rule.
- Using `_geoPoint({lat}, {lng})` in the `sort` parameter at search leads the engine to return a `_geoDistance` within the search results. This field represents the distance in meters of the document from the specified `_geoPoint`.
- Add an `invalid_geo_field` error to handle badly formed _geo field at document indexing.

# II. Motivation

According to our user feedback, the lack of a geo-search feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geo-search capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using `geohash` to be able to geo-search documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.

# III. Future Considerations

- Handling array of geo points in the document object.
- Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geo-hash etc..
- Add built-in filter rules for polygon and bounding-box. e.g. `_geoPoly`, `_geoBox`.
---

### Discovery Issue

https://github.com/meilisearch/product/issues/42