### PR TITLE
Refashion Update APIs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   api-diff:

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -27,6 +27,7 @@ components:
   schemas:
     timestamp:
       type: string
+      description: An `ISO-8601` format for date/time/duration.
       example: '2019-11-20T09:40:33.711324Z'
     index:
       type: object
@@ -253,75 +254,86 @@ components:
         - exhaustiveNbHits
         - processingTimeMs
         - query
-    update:
+    task:
       type: object
       description: |
         MeiliSearch is an asynchronous API. It means that the API does not behave as you would typically expect when handling the request's responses.
 
         Some operations are put in a queue and will be executed in turn (asynchronously). In this case, the server response contains the identifier to track the execution of the operation.
 
-        [Learn More](https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html).
+        [Learn More](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html).
       additionalProperties: false
       examples:
-        - status: processed
-          updateId: 0
-          type:
-            name: DocumentAddition
-            number: 10
-          enqueuedAt: '2019-11-20T09:40:33.711324Z'
-          processedAt: '2019-11-20T09:40:33.711324Z'
-          duration: 5
+        - uid: 0
+          indexUid: movies
+          status: succeeded
+          type: documentsAddition
+          details:
+            numberOfDocuments: 10
+          duration: PT5S
+          enqueuedAt: '2021-01-01T09:39:00.000000Z'
+          startedAt: '2021-01-01T09:40:00.000000Z'
+          finishedAt: '2021-01-01T09:40:05.000000Z'
       properties:
+        uid:
+          type: integer
+          description: The unique sequential identifier of the task
+        indexUid:
+          type: string
+          description: The unique identifier of the index where this task is operated
         status:
           type: string
-          description: The status of the operation.
+          description: The status of the task
           enum:
             - enqueued
             - processing
-            - processed
+            - succeeded
             - failed
-          example: processed
-        updateId:
-          type: integer
-          description: The id of the update.
+          example: succeeded
         type:
+          type: string
+          description: The type of the task
+          enum:
+            - documentsAdditions
+            - documentsPartial
+            - documentsDeletion
+            - settingsUpdate
+            - clearAll
+        details:
           type: object
-          additionalProperties: false
-          required:
-            - name
-          description: Type object for the update task
+          description: Details information of the task payload.
           properties:
-            name:
-              type: string
-              description: Name of operation
-              example: DocumentAddition
-              enum:
-                - DocumentAddition
-                - Settings
-                - DocumentsDeletion
-                - ClearAll
-                - DocumentsPartial
-            number:
+            numberOfDocuments:
               type: integer
-              description: Number of documents impacted when the information can be given.
+              description: Number of documents impacted when the information can be given for the task.
             settings:
               $ref: '#/components/schemas/settings'
-        enqueuedAt:
-          $ref: '#/components/schemas/timestamp'
-        processedAt:
-          $ref: '#/components/schemas/timestamp'
-        duration:
-          type: number
-          description: The number of seconds taken to complete the operation.
         error:
+          description: Error object containing error details and context when a task has a failed status.
+          $ref: '#/components/schemas/error'
+        duration:
           type: string
-          description: |
-            A string describing [the error that occurred](https://docs.meilisearch.com/errors).
+          description: Total elasped time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`
+          nullable: true
+        enqueuedAt:
+          description: Represent the date and time as a `ISO-8601` format when the task has been enqueued
+          $ref: '#/components/schemas/timestamp'
+        startedAt:
+          $ref: '#/components/schemas/timestamp'
+          description: Represent the date and time as a `ISO-8601` format when the task has been dequeued and started to be processed. Default is set to `null`
+          nullable: true
+        finishedAt:
+          $ref: '#/components/schemas/timestamp'
+          description: Represent the date and time as a `ISO-8601` format when the task has failed or succeeded. Default is set to `null`
+          nullable: true
       required:
+        - uid
+        - indexUid
         - status
-        - updateId
         - type
         - enqueuedAt
+        - startedAt
+        - finishedAt
     synonyms:
       type: object
       description: List of associated words treated similarly. A word associated to an array of word as synonyms.
@@ -520,10 +532,10 @@ components:
       required: true
       schema:
         type: any
-    updateId:
-      name: updateId
+    taskUid:
+      name: taskUid
       in: path
-      description: The update unique identifier
+      description: The task unique identifier
       required: true
       schema:
         type: number
@@ -652,16 +664,32 @@ components:
           schema:
             type: object
             properties:
-              updateId:
+              uid:
                 type: number
-                description: 'This `updateId` allows you to [track the current update](https://docs.meilisearch.com/reference/api/updates.html).'
+                description: 'This `uid` allows you to [track the current task](https://docs.meilisearch.com/reference/api/tasks.html).'
+              indexUid:
+                type: string
+                description: The unique identifier of the index where this task is operated
+              status:
+                type: string
+                description: The status of the task
+                example: enqueued
+              enqueuedAt:
+                $ref: '#/components/schemas/timestamp'
+                description: Represent the date and time as `ISO-8601` format when the task has been enqueued
             additionalProperties: false
             required:
-              - updateId
+              - uid
+              - indexUid
+              - status
+              - enqueuedAt
           examples:
             Example:
               value:
-                updateId: 1
+                uid: 0
+                indexUid: movies
+                status: enqueued
+                enqueuedAt: '2021-07-19T14:31:16.920473Z'
     '204':
       description: No Content
     '401':
@@ -720,9 +748,9 @@ tags:
       * A POST route: this is the preferred route when using API authentication, as it allows [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) caching and better performances.
       * A GET route: the usage of this route is discouraged, unless you have good reason to do otherwise (specific caching abilities for example).
       Other than the differences mentioned above, the two routes are strictly equivalent.
-  - name: Updates
+  - name: Tasks
     description: |
-      The `updates` route gives information about the progress of the [asynchronous processes](https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html).
+      The `tasks` route gives information about the progress of the [asynchronous tasks](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html).
   - name: Keys
     description: |
       Each instance of MeiliSearch has three keys: a master, a private, and a public. Each key has a given set of permissions on the API routes.
@@ -2170,14 +2198,14 @@ paths:
           description: Not Found
     parameters:
       - $ref: '#/components/parameters/indexUid'
-  '/indexes/{indexUid}/updates':
+  '/indexes/{indexUid}/tasks':
     get:
-      operationId: indexes.updates.list
-      summary: Get all update status
+      operationId: indexes.tasks.list
+      summary: Get all tasks of an index
       description: |
-        Get the status of all [updates](https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html) in a given [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
+        Get all [tasks](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html) of an [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
       tags:
-        - Updates
+        - Tasks
       security:
         - apiKey: []
       responses:
@@ -2186,62 +2214,53 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/update'
+                type: object
+                properties:
+                  '':
+                    $ref: '#/components/schemas/task'
               examples:
                 Example:
                   value:
-                    - status: processed
-                      updateId: 0
-                      type:
-                        name: DocumentsAddition
-                        number: 6
-                      duration: 0.031
-                      enqueuedAt: '2021-07-05T12:59:17.035788Z'
-                      processedAt: '2021-07-05T12:59:17.067453Z'
-                    - status: processed
-                      updateId: 1
-                      type:
-                        name: DocumentsAddition
-                        number: 6
-                      duration: 0.043
-                      enqueuedAt: '2021-07-06T07:45:49.883179Z'
-                      processedAt: '2021-07-06T07:45:49.927102Z'
-                    - status: processed
-                      updateId: 2
-                      type:
-                        name: Settings
-                        settings:
-                          searchableAttributes:
-                            - name
-                            - genre
-                          stopWords:
-                            - of
-                            - the
-                          synonyms:
-                            HP:
-                              - Harry Potter
-                            harry potter:
-                              - HP
-                          distinctAttribute: name
-                      duration: 0.042
-                      enqueuedAt: '2021-07-19T15:21:44.984611Z'
-                      processedAt: '2021-07-19T15:21:45.027818Z'
+                    data:
+                      - uid: 1
+                        indexUid: movies
+                        status: succeeded
+                        type: documentsAddition
+                        details:
+                          numberOfDocuments: 79000
+                        duration: PT2S
+                        enqueuedAt: '2021-01-01T09:39:00.000000Z'
+                        startedAt: '2021-01-01T09:39:01.000000Z'
+                        finishedAt: '2021-01-01T09:39:02.000000Z'
+                      - uid: 0
+                        indexUid: movies
+                        status: failed
+                        type: documentsAddition
+                        details:
+                          numberOfDocuments: 67493
+                        error:
+                          message: missing primary key
+                          errorCode: missing_primary_key
+                          errorType: invalid_request_error
+                          errorLink: 'https://docs.meilisearch.com/errors#missing_primary_key'
+                        duration: PT5S
+                        enqueuedAt: '2021-01-01T09:38:00.000000Z'
+                        startedAt: '2021-01-01T09:38:02.000000Z'
+                        finishedAt: '2021-01-01T09:38:07.000000Z'
         '401':
           $ref: '#/components/responses/401'
         '404':
           description: Not Found
     parameters:
       - $ref: '#/components/parameters/indexUid'
-  '/indexes/{indexUid}/updates/{updateId}':
+  '/indexes/{indexUid}/tasks/{taskUid}':
     get:
-      operationId: indexes.updates.get
-      summary: Get an update status
+      operationId: indexes.tasks.get
+      summary: Get a task of an index
       description: |
-        Get the status of an [update](https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html) in a given [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
+        Get a [task](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html) of an [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
       tags:
-        - Updates
+        - Tasks
       security:
         - apiKey: []
       responses:
@@ -2250,15 +2269,27 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/update'
-              examples: {}
+                $ref: '#/components/schemas/task'
+              examples:
+                Example:
+                  value:
+                    uid: 1
+                    indexUid: movies
+                    status: succeeded
+                    type: DocumentsAddition
+                    details:
+                      numberOfDocuments: 79000
+                    duration: PT1S
+                    enqueuedAt: '2021-01-01T09:39:00.000000Z'
+                    startedAt: '2021-01-01T09:39:01.000000Z'
+                    finishedAt: '2021-01-01T09:39:02.000000Z'
         '401':
           $ref: '#/components/responses/401'
         '404':
           description: Not Found
     parameters:
       - $ref: '#/components/parameters/indexUid'
-      - $ref: '#/components/parameters/updateId'
+      - $ref: '#/components/parameters/taskUid'
   /keys:
     get:
       operationId: keys.get
@@ -2369,4 +2400,102 @@ paths:
                     pkgVersion: 0.22.0
         '401':
           $ref: '#/components/responses/401'
+  /tasks:
+    get:
+      summary: Get all tasks
+      description: 'Get all [tasks](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html)'
+      tags:
+        - tasks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/task'
+              examples:
+                Example:
+                  value:
+                    data:
+                      - uid: 1
+                        indexUid: movies
+                        status: succeeded
+                        type: documentsAddition
+                        details:
+                          numberOfDocuments: 79000
+                        duration: PT1S
+                        enqueuedAt: '2021-01-01T09:39:00.000000Z'
+                        startedAt: '2021-01-01T09:39:01.000000Z'
+                        finishedAt: '2021-01-01T09:39:02.000000Z'
+                      - uid: 0
+                        indexUid: movies_Review
+                        status: failed
+                        type: documentsAddition
+                        details:
+                          numberOfDocuments: 67493
+                        error:
+                          message: missing primary key
+                          errorCode: missing_primary_key
+                          errorType: invalid_request_error
+                          errorLink: 'https://docs.meilisearch.com/errors#missing_primary_key'
+                        duration: PT5S
+                        enqueuedAt: '2021-01-01T09:38:00.000000Z'
+                        startedAt: '2021-01-01T09:38:02.000000Z'
+                        finishedAt: '2021-01-01T09:38:07.000000Z'
+      operationId: tasks.list
+      parameters: []
+      security:
+        - apiKey: []
+  '/tasks/:taskUid':
+    get:
+      summary: Get a task
+      description: 'Get a [task](https://docs.meilisearch.com/learn/advanced/asynchronous_tasks.html) '
+      tags:
+        - tasks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/task'
+              examples:
+                Example:
+                  value:
+                    uid: 1
+                    indexUid: movies
+                    status: succeeded
+                    type: documentsAddition
+                    details:
+                      numberOfDocuments: 79000
+                    duration: PT1S
+                    enqueuedAt: '2021-01-01T09:39:00.000000Z'
+                    startedAt: '2021-01-01T09:39:01.000000Z'
+                    finishedAt: '2021-01-01T09:39:02.000000Z'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+              examples:
+                Example:
+                  value:
+                    message: 'Task :taskUid not found.'
+                    errorCode: task_not_found
+                    errorType: invalid_requet_error
+                    link: 'https://docs.meilisearch.com/errors/#task_not_found'
+      operationId: tasks.get
+      parameters: []
+      security:
+        - apiKey: []
+    parameters:
+      - $ref: '#/components/parameters/taskUid'
 security: []

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -37,8 +37,282 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
 The main motivation is to stabilize the current `update` resource to a version that conforms to our API convention and thus allow future evolutions on a more solid base. We would like to modify the name `update`, its format is also to be reviewed because some attributes are not immediately clear, either in the possible values or in the chosen names.
 
 ### III. Explanation
+
+#### 1. `task` object definition
+
+##### **Fully Qualified `task` object**
+
+> This fully qualified version appears as response object on `task` dedicated endpoints.
+
+| field   | type    | description                     |
+|---------|---------|---------------------------------|
+| uid      | integer | Unique sequential identifier           |
+| indexUid | string | Unique index identifier |
+| status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
+| type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate` |
+| details    | object  |  Details information of the type payload. See examples |
+| error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
+| duration | number | Total elasped seconds the engine was in `processing` state. Default is set to `null`  |
+| enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
+| startedAt | string | Represent the date and time as `ISO-8601` format when the task has been dequeued and started to be processed. Default is set to `null`|
+| finishedAt | string | Represent the date and time as `ISO-8601` format when the task has `failed` or `succeeded`. Only displayed when the status is `failed` or `succeeded`. Default is set to `null` |
+
+> 💡 The order of the fields must be returned in this order.
+>
+> 💡 This summarized version appears only in `202 Accepted` responses.
+>
+> 🔮 Future consideration - `task` object contained in a list could have a `link` attribute allowing direct access to the resource.
+
+##### Summarized `task` Object for `202 Accepted`
+
+| field   | type    | description                     |
+|---------|---------|---------------------------------|
+| uid      | integer | Unique sequential identifier           |
+| indexUid | string | Unique index identifier |
+| status  | string  | Status of the task. Value is `enqueued` |
+| enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
+
+> 💡 The order of the fields must be returned in this order.
+>
+> 💡 This summarized version appears only in `202 Accepted` responses.
+>
+> 🔮 Future consideration - `task` object contained in a list of `tasks` could have a `link` attribute allowing direct access to the resource.
+
+#### 2. `status` field enum
+
+| old        | new           |
+|------------|---------------|
+| enqueued   | -             |
+| processing | -             |
+| processed  | **succeeded** |
+| failed     | -             |
+
+> Better semantic differentiation than `processing` and `processed`. The final status of a processed task is `succeeded` or `failed`.
+
+#### 3. `type` field Enum changes
+
+| old        | new           |
+|------------|---------------|
+| DocumentsAddition | documentsAddition     |
+| DocumentsPartial | documentsPartial   |
+| DocumentsDeletion  | documentsDeletion |
+| Settings     | settingsUpdate |
+
+> Type values follow a `camelCase` naming convention.
+>
+> `Settings` is updated to be more precise with the name `settingsUpdate`.
+>
+> Future consideration - Dedicated type name for sub-settings endpoints usage `SearchableAttributesUpdate`.
+
+#### 4. Examples
+
+e.g. A fully qualified `task` object in `enqueued` state.
+
+```json=
+{
+        "uid": 0,
+        "indexUid": "movies",
+        "status": "enqueued",
+        "type": "settingsUpdate",
+        "details": {
+            "rankingRules": [
+                "typo",
+                "desc(ranking)",
+                "words",
+                "proximity",
+                "attribute",
+                "wordsPosition",
+                "exactness"
+            ]
+        },
+        "duration": null,
+        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+        "startedAt": null,
+        "finishedAt": null
+}
+```
+
+e.g. A fully qualified `task` object in `processing`.
+
+```json=
+{
+        "uid": 0,
+        "indexUid": "movies",
+        "status": "processing",
+        "type": "settingsUpdate",
+        "details": {
+            "rankingRules": [
+                "typo",
+                "desc(ranking)",
+                "words",
+                "proximity",
+                "attribute",
+                "wordsPosition",
+                "exactness"
+            ]
+        },
+        "duration": null,
+        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+        "startedAt": "2021-08-10T14:29:18.000000Z",
+        "finishedAt": null,
+}
+```
+
+e.g. A fully qualified `task` object in `succeeded` state.
+
+```json=
+{
+        "uid": 0,
+        "indexUid": "movies",
+        "status": "succeeded",
+        "type": "settingsUpdate",
+        "details": {
+            "rankingRules": [
+                "typo",
+                "desc(ranking)",
+                "words",
+                "proximity",
+                "attribute",
+                "wordsPosition",
+                "exactness"
+            ]
+        },
+        "duration": 1.0,
+        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+        "startedAt": "2021-08-10T14:29:18.000000Z",
+        "finishedAt": "2021-08-10T14:29:19.000000Z"
+}
+```
+
+e.g. A fully qualified `task` object in `failed` state.
+
+```json=
+{
+        "uid": 0,
+        "indexUid": "movies",
+        "status": "failed",
+        "type": "settingsUpdate",
+        "details": {
+            "rankingRules": [
+                "typo",
+                "desc(ranking)",
+                "words",
+                "proximity",
+                "attribute",
+                "wordsPosition",
+                "exactness"
+            ]
+        },
+        "error": {
+            "message": "invalid criterion wordsPosition",
+            "code": "internal",
+            "type": "internal_error",
+            "link": "https://docs.meilisearch.com/errors#internal",
+        },
+        "duration": 1.0,
+        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+        "startedAt": "2021-08-10T14:29:18.000000Z",
+        "finishedAt": "2021-08-10T14:29:19.000000Z",
+}
+```
+
+e.g. A summarized `task` object as a response for a `202 Accepted` HTTP code.
+
+```json=
+{
+    "uid": 0,
+    "indexUid": "movies",
+    "status": "enqueued",
+    "enqueuedAt": "2021-08-11T09:25:53.000000Z"
+}
+```
+
+---
+
+### GET `/tasks`
+
+#### Goal
+
+Allows users to list tasks globally regardless of the indexes involved. Particularly useful to visualize all the tasks.
+
+#### Response Definition
+
+- `task` objects are contained in a `data` array.
+- By default, objects are sorted by desc order on `uid` field. So the most recent tasks appear first.
+
+#### Response Example
+
+```json=
+{
+    "data": [
+        {
+            "uid": 1,
+            "status": "enqueued",
+            "indexUid": "movies",
+            "type": "documentsAddition",
+            "duration": null,
+            "enqueuedAt": "2021-08-12T10:00:00.000000Z",
+            "startedProcessingAt": null,
+            "finishedAt": null
+        },
+        {
+            "uid": 0,
+            "status": "succeeded",
+            "indexUid": "movies",
+            "type": "documentsAddition",
+            "details": {
+                "number": 100
+            },
+            "duration": 16.000,
+            "enqueuedAt": "2021-08-11T09:25:53.000000Z",
+            "startedAt": "2021-08-11T10:03:00.000000Z",
+            "finishedAt": "2021-08-11T10:03:16.000000Z"
+        }
+    ]
+}
+```
+
+> 🔮 Future consideration - Add a keyset pagination
+>
+> 🔮 Future consideration - Add dedicated query parameters for filtering
+
+### GET `/tasks/{uid}`
+
+#### Goal
+
+Allows users to get a detailed `task` object retrieved by the `uid` field regardless of the index involved.
+
+> 🔮 Future consideration -  Reconsider usage of `/indexes/indexUId/tasks/{uid}` route since the two routes are stricly similar.
+
+#### Response Example
+
+e.g. `/tasks/1`
+
+```json=
+{
+
+    {
+        "uid": 1,
+        "status": "enqueued",
+        "indexUid": "movies",
+        "type": "documentsAddition",
+        "duration": null,
+        "enqueuedAt": "2021-08-12T10:00:00.000000Z",
+        "startedProcessingAt": null,
+        "finishedAt": null
+    }
+}
+```
+
+---
+
+### GET `/indexes/{indexUid}/tasks`
+
 TBD
 
+### GET `/indexes/{indexUid}/tasks/{tasksUid}`
+
+TBD
 
 ### IV. Finalized Key Changes
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -1,7 +1,7 @@
 - Title: Refashion Updates APIs
 - Start Date: 2021-08-13
 - Specification PR: [#55](https://github.com/meilisearch/specifications/pull/60)
-- Discovery Issue: [#43](https://github.com/meilisearch/product/issues/43)
+- Discovery Issue: [#48](https://github.com/meilisearch/product/issues/48)
 
 # Refashion Updates APIs
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -29,6 +29,7 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
     - The possible values for the `type` field are reworked to be more clear and consistent with our naming rules.
     - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object.
     - An `indexUid` field is added to give information about the related index on which the task is performed.
+    - `duration` format has been updated to express an `ISO 8601` duration.
     - `processed` status changes to `succeeded`.
     - `startedProcessingAt` is updated to `startedAt`.
     - `processedAt` is updated to `finishedAt`.
@@ -52,10 +53,10 @@ The main motivation is to stabilize the current `update` resource to a version t
 | uid      | integer | Unique sequential identifier           |
 | indexUid | string | Unique index identifier |
 | status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
-| type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate` |
-| details | object |  Details information of the task payload. See `details` definition. |
+| type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
+| details | object |  Details information of the task payload. See `details` object definition by `type` part. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
-| duration | float | Total elasped seconds the engine was in `processing` state. Represented as a fractional number of seconds. Default is set to `null`  |
+| duration | string | Total elasped time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`.  |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
 | startedAt | string | Represent the date and time as `ISO-8601` format when the task has been dequeued and started to be processed. Default is set to `null`|
 | finishedAt | string | Represent the date and time as `ISO-8601` format when the task has `failed` or `succeeded`. Default is set to `null` |
@@ -92,9 +93,10 @@ The main motivation is to stabilize the current `update` resource to a version t
 | old        | new           |
 |------------|---------------|
 | DocumentsAddition | documentsAddition     |
-| DocumentsPartial | documentsPartial   |
+| DocumentsPartial | documentsPartial  |
 | DocumentsDeletion  | documentsDeletion |
 | Settings     | settingsUpdate |
+| ClearAll | clearAll |
 
 > 👍 Type values follow a `camelCase` naming convention.
 >
@@ -380,12 +382,12 @@ Allows users to list tasks of a particular index.
 
 #### 5. `task_not_found` error definition
 
-| field     | value                                                                                                                |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| message   | Task *:taskUid* not found.                                                                                           |
-| code      | task_not_found                                                                                                       |
-| type      | invalid_request_error                                                                                                |
-| mink      | *Link to the dedicated error page*                                                                                   |
+| field     | type   | value                                                                                                          |
+|-----------|--------|----------------------------------------------------------------------------------------------------------------|
+| message   | string | Task *:taskUid* not found.                                                                                     |
+| code      | string | task_not_found                                                                                                 |
+| type      | string | invalid_request_error                                                                                          |
+| link      | url    | https://docs.meilisearch.com/errors/#task_not_found                                                            |
 
 ### IV. Finalized Key Changes
 
@@ -393,7 +395,10 @@ Allows users to list tasks of a particular index.
 
 ### I. Measuring
 
-N/A
+- Number of call on `indexes/:indexUid/tasks` per instance
+- Number of call on `indexes/:indexUid/tasks/:taskUid` per instance
+- Number of call on `tasks` per instance
+- Number of call on `tasks/:taskUid` per instance
 
 ###
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -1,0 +1,54 @@
+- Title: Refashion Updates APIs
+- Start Date: 2021-08-13
+- Specification PR: [#55](https://github.com/meilisearch/specifications/pull/60)
+- Discovery Issue: [#43](https://github.com/meilisearch/product/issues/43)
+
+# Refashion Updates APIs
+
+## 1. Functional Specification
+
+### I. Summary
+
+The term `update` is not the best choice as it can be confused with document updates or `settings`. We have chosen to replace this term with `task`, which is more generic and better reflects the meaning of this API resource.
+
+As an additional change, we have reworked the format of an update to make it more in line with our expectations of an API that is supposed to be easily understandable and developer-oriented.
+
+The changes we will make to the response format of the `task` object lists will make it easier to add more functionality in a future iteration. See the Future Possibilities section for a brief overview.
+
+Two new API endpoints are added. Although quite simple, they allow to consult the list of tasks or a specific task without being forced to know the related index.
+
+#### Summary Key Points
+
+-  The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
+-  The format of the `task` object is updated.
+    - `updateId` becomes `uid`.
+    - Attributes of an error appearing in a `failed` `task` are now contained in a dedicated `error` object.
+    - `type` is no longer an object. It now becomes a string containing the values of its `name` field previously defined in the `type` object.
+    - The possible values for the `type` field are reworked to be more clear and consistent with our naming rules.
+    - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object.
+    - An `indexUid` field is added to give information about the related index on which the task is performed.
+    - `processed` status changes to `succeeded`.
+    - `startedProcessingAt` is updated to `startedAt`.
+    - `processedAt` is updated to `finishedAt`.
+- `202 Accepted` requests previously returning an `updateId` are now returning a summarized `task` object.
+
+### II. Motivation
+
+The main motivation is to stabilize the current `update` resource to a version that conforms to our API convention and thus allow future evolutions on a more solid base. We would like to modify the name `update`, its format is also to be reviewed because some attributes are not immediately clear, either in the possible values or in the chosen names.
+
+### III. Explanation
+TBD
+
+
+### IV. Finalized Key Changes
+
+## 2. Technical details
+
+### I. Measuring
+
+TBD
+
+## 3. Future Possibilities
+
+- Add pagination on `task` lists.
+- Add filtering capabilities.

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -34,6 +34,8 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
     - `startedProcessingAt` is updated to `startedAt`.
     - `processedAt` is updated to `finishedAt`.
 - `202 Accepted` requests previously returning an `updateId` are now returning a summarized `task` object.
+- `MEILI_MAX_UDB_SIZE` env var is updated `MEILI_MAX_TASK_DB_SIZE`.
+- `--max-udb-size` cli option is updated to `--max-task-db-size`.
 
 
 ### II. Motivation
@@ -380,7 +382,7 @@ Allows users to list tasks of a particular index.
 - 🔴 If the index does not exists, the API returns a `404 Not Found` - `index_not_found` error.
 - 🔴 If the task does not exists, the API returns a `404 Not Found` - `task_not_found` error.
 
-#### 5. `task_not_found` error definition
+#### 6. `task_not_found` error definition
 
 | field     | type   | value                                                                                                          |
 |-----------|--------|----------------------------------------------------------------------------------------------------------------|
@@ -389,7 +391,12 @@ Allows users to list tasks of a particular index.
 | type      | string | invalid_request_error                                                                                          |
 | link      | url    | https://docs.meilisearch.com/errors/#task_not_found                                                            |
 
-### IV. Finalized Key Changes
+#### 7. `MEILI_MAX_UDB_SIZE` env var and `--max-udb-size` cli option
+
+As the notion of `update` no longer exists. The acronym `UDB` is changed by `TASK_DB`.
+
+- `MEILI_MAX_UDB_SIZE` env var is updated to `MEILI_MAX_TASK_DB_SIZE`.
+- `--max-udb-size` cli option is updated to `--max-task-db-size`.
 
 ## 2. Technical details
 
@@ -399,8 +406,6 @@ Allows users to list tasks of a particular index.
 - Number of call on `indexes/:indexUid/tasks/:taskUid` per instance
 - Number of call on `tasks` per instance
 - Number of call on `tasks/:taskUid` per instance
-
-###
 
 ## 3. Future Possibilities
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -382,7 +382,7 @@ Allows users to list tasks of a particular index.
 
 | field     | value                                                                                                                |
 |-----------|----------------------------------------------------------------------------------------------------------------------|
-| message   | Task *task uid* not found.                                                                                           |
+| message   | Task *:taskUid* not found.                                                                                           |
 | errorCode | task_not_found                                                                                                       |
 | errorType | invalid_request_error                                                                                                |
 | errorLink | *Link to the dedicated error page*                                                                                   |

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -19,8 +19,8 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
 
 #### Summary Key Points
 
--  The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
-- 2 API endpoints are added. `/tasks` and `tasks/{taskUid}`.
+- The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
+- Tasks are now also accessible as an independent resource of an index. `GET - /tasks`; `GET - /tasks/:taskUid`
 - A `task_not_found` error is introduced.
 -  The format of the `task` object is updated.
     - `updateId` becomes `uid`.

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -50,7 +50,7 @@ The main motivation is to stabilize the current `update` resource to a version t
 | indexUid | string | Unique index identifier |
 | status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
 | type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate` |
-| details    | object  |  Details information of the type payload. See examples |
+| details    | object  |  Details information of the type payload. See examples. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
 | duration | number | Total elasped seconds the engine was in `processing` state. Default is set to `null`  |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
@@ -85,7 +85,7 @@ The main motivation is to stabilize the current `update` resource to a version t
 | processed  | **succeeded** |
 | failed     | -             |
 
-> Better semantic differentiation than `processing` and `processed`. The final status of a processed task is `succeeded` or `failed`.
+> 👍 Better semantic differentiation than `processing` and `processed`. The final status of a processed task is `succeeded` or `failed`.
 
 #### 3. `type` field Enum changes
 
@@ -96,11 +96,11 @@ The main motivation is to stabilize the current `update` resource to a version t
 | DocumentsDeletion  | documentsDeletion |
 | Settings     | settingsUpdate |
 
-> Type values follow a `camelCase` naming convention.
+> 👍 Type values follow a `camelCase` naming convention.
 >
-> `Settings` is updated to be more precise with the name `settingsUpdate`.
+> 💡 `Settings` is updated to be more precise with the name `settingsUpdate`.
 >
-> Future consideration - Dedicated type name for sub-settings endpoints usage `SearchableAttributesUpdate`.
+> 🔮 Future consideration - Dedicated type name for sub-settings endpoints usage `SearchableAttributesUpdate`.
 
 #### 4. Examples
 
@@ -130,7 +130,7 @@ e.g. A fully qualified `task` object in `enqueued` state.
 }
 ```
 
-e.g. A fully qualified `task` object in `processing`.
+e.g. A fully qualified `task` object in `processing` state.
 
 ```json=
 {

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -383,9 +383,9 @@ Allows users to list tasks of a particular index.
 | field     | value                                                                                                                |
 |-----------|----------------------------------------------------------------------------------------------------------------------|
 | message   | Task *:taskUid* not found.                                                                                           |
-| errorCode | task_not_found                                                                                                       |
-| errorType | invalid_request_error                                                                                                |
-| errorLink | *Link to the dedicated error page*                                                                                   |
+| code      | task_not_found                                                                                                       |
+| type      | invalid_request_error                                                                                                |
+| mink      | *Link to the dedicated error page*                                                                                   |
 
 ### IV. Finalized Key Changes
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -271,7 +271,7 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
 
 ##### Requirements
 
-> 💡`task` objects are contained in a `data` array.
+> 💡 `task` objects are contained in a `data` array.
 >
 > 💡 By default, objects are sorted by `desc` order on `uid` field. So the most recent tasks appear first.
 
@@ -382,14 +382,26 @@ Allows users to list tasks of a particular index.
 - 🔴 If the index does not exists, the API returns a `404 Not Found` - `index_not_found` error.
 - 🔴 If the task does not exists, the API returns a `404 Not Found` - `task_not_found` error.
 
-#### 6. `task_not_found` error definition
+#### 6. `task_not_found` error
 
-| field     | type   | value                                                                                                          |
-|-----------|--------|----------------------------------------------------------------------------------------------------------------|
-| message   | string | Task *:taskUid* not found.                                                                                     |
-| code      | string | task_not_found                                                                                                 |
-| type      | string | invalid_request_error                                                                                          |
-| link      | url    | https://docs.meilisearch.com/errors/#task_not_found                                                            |
+##### Context
+
+This error happens when a requested task can't be found.
+
+##### Error Definition
+
+HTTP Code: `404 Not Found`
+
+```json
+{
+    "message": "Task :taskUid not found.",
+    "code": "task_not_found",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#task_not_found"
+}
+```
+
+- The `:taskUid` is inferred when the message is generated.
 
 #### 7. `MEILI_MAX_UDB_SIZE` env var and `--max-udb-size` cli option
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -59,8 +59,6 @@ The main motivation is to stabilize the current `update` resource to a version t
 
 > 💡 The order of the fields must be returned in this order.
 >
-> 💡 This summarized version appears only in `202 Accepted` responses.
->
 > 🔮 Future consideration - `task` object contained in a list could have a `link` attribute allowing direct access to the resource.
 
 ##### Summarized `task` Object for `202 Accepted`

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -118,11 +118,10 @@ e.g. A fully qualified `task` object in `enqueued` state.
     "details": {
         "rankingRules": [
             "typo",
-            "desc(ranking)",
+            "ranking:desc",
             "words",
             "proximity",
             "attribute",
-            "wordsPosition",
             "exactness"
         ]
     },
@@ -137,25 +136,24 @@ e.g. A fully qualified `task` object in `processing` state.
 
 ```json
 {
-        "uid": 0,
-        "indexUid": "movies",
-        "status": "processing",
-        "type": "settingsUpdate",
-        "details": {
-            "rankingRules": [
-                "typo",
-                "desc(ranking)",
-                "words",
-                "proximity",
-                "attribute",
-                "wordsPosition",
-                "exactness"
-            ]
-        },
-        "duration": null,
-        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
-        "startedAt": "2021-08-10T14:29:18.000000Z",
-        "finishedAt": null,
+    "uid": 0,
+    "indexUid": "movies",
+    "status": "processing",
+    "type": "settingsUpdate",
+    "details": {
+        "rankingRules": [
+            "typo",
+            "ranking:desc",
+            "words",
+            "proximity",
+            "attribute",
+            "exactness"
+        ]
+    },
+    "duration": null,
+    "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+    "startedAt": "2021-08-10T14:29:18.000000Z",
+    "finishedAt": null
 }
 ```
 
@@ -170,11 +168,10 @@ e.g. A fully qualified `task` object in `succeeded` state.
     "details": {
         "rankingRules": [
             "typo",
-            "desc(ranking)",
+            "ranking:desc",
             "words",
             "proximity",
             "attribute",
-            "wordsPosition",
             "exactness"
         ]
     },
@@ -196,7 +193,7 @@ e.g. A fully qualified `task` object in `failed` state.
     "details": {
         "rankingRules": [
             "typo",
-            "desc(ranking)",
+            "ranking:desc",
             "words",
             "proximity",
             "attribute",
@@ -210,7 +207,7 @@ e.g. A fully qualified `task` object in `failed` state.
         "type": "internal_error",
         "link": "https://docs.meilisearch.com/errors#internal",
     },
-    "duration": 1.0,
+    "duration": "PT1S",
     "enqueuedAt": "2021-08-10T14:29:17.000000Z",
     "startedAt": "2021-08-10T14:29:18.000000Z",
     "finishedAt": "2021-08-10T14:29:19.000000Z"

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -60,10 +60,10 @@ The motivation is to stabilize the current `update` resource to a version that c
 | uid      | integer | Unique sequential identifier           |
 | indexUid | string | Unique index identifier |
 | status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
-| type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
+| type    | string  | Type of the task. Possible values are `indexCreation`, `indexUpdate`, `indexDeletion`, `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
 | details | object |  Details information of the task payload. `numberOfDocuments` represent the number of deduplicated documents processed for `documentsAddition`, `documentsPartial` and `documentsDeletion` type. Details contains any settings object depending of the `task` payload for a `settingsUpdate`. `clearAll`, `indexCreation`, `indexUpdate`, `indexDeletion` does not provide a `details` object. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
- | duration | string | Total elapsed time the engine was in processing state expressed as an `ISO-8601` duration format. Default is set to `null`.  |
+ | duration | string | Total elapsed time the engine was in processing state expressed as an `ISO-8601` duration format. Times below the second can be expressed with the `.` notation, e.g., `PT0.5S` to express `500ms`. Default is set to `null`.   |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
 | startedAt | string | Represent the date and time as `ISO-8601` format when the task has been dequeued and started to be processed. Default is set to `null`|
 | finishedAt | string | Represent the date and time as `ISO-8601` format when the task has `failed` or `succeeded`. Default is set to `null` |

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -57,7 +57,7 @@ The main motivation is to stabilize the current `update` resource to a version t
 | indexUid | string | Unique index identifier |
 | status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
 | type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
-| details | object |  Details information of the task payload. `numberOfDocuments` represent the number of deduplicated documents processed for `documentsAddition`, `documentsPartial` and `documentsDeletion`. Details can also contains any settings object depending of the `task` payload for a `settingsUpdate`. `clearAll` does not provide a `details`. |
+| details | object |  Details information of the task payload. `numberOfDocuments` represent the number of deduplicated documents processed for `documentsAddition`, `documentsPartial` and `documentsDeletion` type. Details contains any settings object depending of the `task` payload for a `settingsUpdate`. `clearAll` does not provide a `details`. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
  | duration | string | Total elapsed time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`.  |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -59,7 +59,7 @@ The main motivation is to stabilize the current `update` resource to a version t
 | type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
 | details | object |  Details information of the task payload. `numberOfDocuments` represent the number of deduplicated documents processed for `documentsAddition`, `documentsPartial` and `documentsDeletion`. Details can also contains any settings object depending of the `task` payload for a `settingsUpdate`. `clearAll` does not provide a `details`. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
-| duration | string | Total elasped time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`.  |
+ | duration | string | Total elapsed time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`.  |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
 | startedAt | string | Represent the date and time as `ISO-8601` format when the task has been dequeued and started to be processed. Default is set to `null`|
 | finishedAt | string | Represent the date and time as `ISO-8601` format when the task has `failed` or `succeeded`. Default is set to `null` |

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -503,6 +503,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 - Add a pagination system for on `/tasks` and `indexes/:indexUid/tasks` lists.
 - Add enhanced filtering capabilities.
+- Simplify `documentsAddition` and `documentsPartial` type and elaborate on metadata.
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.
 - Reconsider existence of `/indexes/:indexUid/tasks/:taskUid` route it is similar to `/tasks/:taskUid`.

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -1,6 +1,6 @@
 - Title: Refashion Updates APIs
 - Start Date: 2021-08-13
-- Specification PR: [#55](https://github.com/meilisearch/specifications/pull/60)
+- Specification PR: [#60](https://github.com/meilisearch/specifications/pull/60)
 - Discovery Issue: [#48](https://github.com/meilisearch/product/issues/48)
 
 # Refashion Updates APIs

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -27,7 +27,7 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
     - Attributes of an error appearing in a `failed` `task` are now contained in a dedicated `error` object.
     - `type` is no longer an object. It now becomes a string containing the values of its `name` field previously defined in the `type` object.
     - The possible values for the `type` field are reworked to be more clear and consistent with our naming rules.
-    - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object.
+    - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object. Previous `number` key is renamed `numberOfDocuments`.
     - An `indexUid` field is added to give information about the related index on which the task is performed.
     - `duration` format has been updated to express an `ISO 8601` duration.
     - `processed` status changes to `succeeded`.
@@ -36,6 +36,7 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
 - `202 Accepted` requests previously returning an `updateId` are now returning a summarized `task` object.
 - `MEILI_MAX_UDB_SIZE` env var is updated `MEILI_MAX_TASK_DB_SIZE`.
 - `--max-udb-size` cli option is updated to `--max-task-db-size`.
+- `task` object list are now returned under a `results` array.
 
 
 ### II. Motivation
@@ -56,7 +57,7 @@ The main motivation is to stabilize the current `update` resource to a version t
 | indexUid | string | Unique index identifier |
 | status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
 | type    | string  | Type of the task. Possible values are `documentsAddition`, `documentsPartial`, `documentsDeletion`, `settingsUpdate`, `clearAll` |
-| details | object |  Details information of the task payload. See `details` object definition by `type` part. |
+| details | object |  Details information of the task payload. `numberOfDocuments` represent the number of deduplicated documents processed for `documentsAddition`, `documentsPartial` and `documentsDeletion`. Details can also contains any settings object depending of the `task` payload for a `settingsUpdate`. `clearAll` does not provide a `details`. |
 | error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
 | duration | string | Total elasped time the engine was in processing state expressed as a `ISO-8601` duration format. Default is set to `null`.  |
 | enqueuedAt | string | Represent the date and time as `ISO-8601` format when the task has been enqueued |
@@ -110,25 +111,25 @@ e.g. A fully qualified `task` object in `enqueued` state.
 
 ```json
 {
-        "uid": 0,
-        "indexUid": "movies",
-        "status": "enqueued",
-        "type": "settingsUpdate",
-        "details": {
-            "rankingRules": [
-                "typo",
-                "desc(ranking)",
-                "words",
-                "proximity",
-                "attribute",
-                "wordsPosition",
-                "exactness"
-            ]
-        },
-        "duration": null,
-        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
-        "startedAt": null,
-        "finishedAt": null
+    "uid": 0,
+    "indexUid": "movies",
+    "status": "enqueued",
+    "type": "settingsUpdate",
+    "details": {
+        "rankingRules": [
+            "typo",
+            "desc(ranking)",
+            "words",
+            "proximity",
+            "attribute",
+            "wordsPosition",
+            "exactness"
+        ]
+    },
+    "duration": null,
+    "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+    "startedAt": null,
+    "finishedAt": null
 }
 ```
 
@@ -162,25 +163,25 @@ e.g. A fully qualified `task` object in `succeeded` state.
 
 ```json
 {
-        "uid": 0,
-        "indexUid": "movies",
-        "status": "succeeded",
-        "type": "settingsUpdate",
-        "details": {
-            "rankingRules": [
-                "typo",
-                "desc(ranking)",
-                "words",
-                "proximity",
-                "attribute",
-                "wordsPosition",
-                "exactness"
-            ]
-        },
-        "duration": 1.0,
-        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
-        "startedAt": "2021-08-10T14:29:18.000000Z",
-        "finishedAt": "2021-08-10T14:29:19.000000Z"
+    "uid": 0,
+    "indexUid": "movies",
+    "status": "succeeded",
+    "type": "settingsUpdate",
+    "details": {
+        "rankingRules": [
+            "typo",
+            "desc(ranking)",
+            "words",
+            "proximity",
+            "attribute",
+            "wordsPosition",
+            "exactness"
+        ]
+    },
+    "duration": "PT1S",
+    "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+    "startedAt": "2021-08-10T14:29:18.000000Z",
+    "finishedAt": "2021-08-10T14:29:19.000000Z"
 }
 ```
 
@@ -188,31 +189,31 @@ e.g. A fully qualified `task` object in `failed` state.
 
 ```json
 {
-        "uid": 0,
-        "indexUid": "movies",
-        "status": "failed",
-        "type": "settingsUpdate",
-        "details": {
-            "rankingRules": [
-                "typo",
-                "desc(ranking)",
-                "words",
-                "proximity",
-                "attribute",
-                "wordsPosition",
-                "exactness"
-            ]
-        },
-        "error": {
-            "message": "invalid criterion wordsPosition",
-            "code": "internal",
-            "type": "internal_error",
-            "link": "https://docs.meilisearch.com/errors#internal",
-        },
-        "duration": 1.0,
-        "enqueuedAt": "2021-08-10T14:29:17.000000Z",
-        "startedAt": "2021-08-10T14:29:18.000000Z",
-        "finishedAt": "2021-08-10T14:29:19.000000Z",
+    "uid": 0,
+    "indexUid": "movies",
+    "status": "failed",
+    "type": "settingsUpdate",
+    "details": {
+        "rankingRules": [
+            "typo",
+            "desc(ranking)",
+            "words",
+            "proximity",
+            "attribute",
+            "wordsPosition",
+            "exactness"
+        ]
+    },
+    "error": {
+        "message": "invalid criterion wordsPosition",
+        "code": "internal",
+        "type": "internal_error",
+        "link": "https://docs.meilisearch.com/errors#internal",
+    },
+    "duration": 1.0,
+    "enqueuedAt": "2021-08-10T14:29:17.000000Z",
+    "startedAt": "2021-08-10T14:29:18.000000Z",
+    "finishedAt": "2021-08-10T14:29:19.000000Z"
 }
 ```
 
@@ -241,7 +242,7 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
 
 ```json
 {
-    "data": [
+    "results": [
         {
             "uid": 1,
             "status": "enqueued",
@@ -258,9 +259,9 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
             "indexUid": "movies",
             "type": "documentsAddition",
             "details": {
-                "number": 100
+                "numberOfDocuments": 100
             },
-            "duration": 16.000,
+            "duration": "PT16S",
             "enqueuedAt": "2021-08-11T09:25:53.000000Z",
             "startedAt": "2021-08-11T10:03:00.000000Z",
             "finishedAt": "2021-08-11T10:03:16.000000Z"
@@ -271,7 +272,7 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
 
 ##### Requirements
 
-> 💡 `task` objects are contained in a `data` array.
+> 💡 `task` objects are contained in a `results` array.
 >
 > 💡 By default, objects are sorted by `desc` order on `uid` field. So the most recent tasks appear first.
 
@@ -293,12 +294,12 @@ Allows users to get a detailed `task` object retrieved by the `uid` field regard
 ```json
 {
     "uid": 1,
-    "status": "enqueued",
     "indexUid": "movies",
+    "status": "enqueued",
     "type": "documentsAddition",
     "duration": null,
     "enqueuedAt": "2021-08-12T10:00:00.000000Z",
-    "startedProcessingAt": null,
+    "startedAt": null,
     "finishedAt": null
 }
 ```
@@ -321,26 +322,26 @@ Allows users to list tasks of a particular index.
 
 ```json
 {
-    "data": [
+    "results": [
         {
             "uid": 1,
-            "status": "enqueued",
             "indexUid": "movies",
+            "status": "enqueued",
             "type": "documentsAddition",
             "duration": null,
             "enqueuedAt": "2021-08-12T10:00:00.000000Z",
-            "startedProcessingAt": null,
+            "startedAt": null,
             "finishedAt": null
         },
         {
             "uid": 0,
-            "status": "succeeded",
             "indexUid": "movies",
+            "status": "succeeded",
             "type": "documentsAddition",
             "details": {
-                "number": 100
+                "numberofDocuments": 100
             },
-            "duration": 16.000,
+            "duration": "PT16S",
             "enqueuedAt": "2021-08-11T09:25:53.000000Z",
             "startedAt": "2021-08-11T10:03:00.000000Z",
             "finishedAt": "2021-08-11T10:03:16.000000Z"
@@ -365,12 +366,12 @@ Allows users to list tasks of a particular index.
 {
 
     "uid": 1,
-    "status": "enqueued",
     "indexUid": "movies",
+    "status": "enqueued",
     "type": "documentsAddition",
     "duration": null,
     "enqueuedAt": "2021-08-12T10:00:00.000000Z",
-    "startedProcessingAt": null,
+    "startedAt": null,
     "finishedAt": null
 }
 ```

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -21,8 +21,9 @@ Two new API endpoints are added. Although quite simple, they allow to consult th
 
 - The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
 - Tasks are now also accessible as an independent resource of an index. `GET - /tasks`; `GET - /tasks/:taskUid`
+- The task `uid` is not incremented by index anymore. The sequence is generated globally.
 - A `task_not_found` error is introduced.
--  The format of the `task` object is updated.
+- The format of the `task` object is updated.
     - `updateId` becomes `uid`.
     - Attributes of an error appearing in a `failed` `task` are now contained in a dedicated `error` object.
     - `type` is no longer an object. It now becomes a string containing the values of its `name` field previously defined in the `type` object.
@@ -270,6 +271,8 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
 ##### Requirements
 
 > 💡 `task` objects are contained in a `results` array.
+>
+> 💡 `task` uid is generated globally. The `uid` of the tasks are no longer scoped to an index.
 >
 > 💡 By default, objects are sorted by `desc` order on `uid` field. So the most recent tasks appear first.
 

--- a/text/0060-refashion-updates-apis.md
+++ b/text/0060-refashion-updates-apis.md
@@ -432,7 +432,7 @@ The main change in the API is that the routes response described below now becom
 
 Errors are now part of the `task` as for other asynchronous operations.
 
-New task types are also added for these operations.
+New task types are also added for these operations. `indexCreation`, `indexUpdate`, and `indexDeletion`.
 
 **Create an index** | `POST` - `/indexes`
 
@@ -453,6 +453,8 @@ New task types are also added for these operations.
     "enqueuedAt": "2021-08-12T10:00:00.000000Z"
 }
 ```
+
+- 💡 Automatic index creation using the `/indexes/:indexToCreate/documents` route generates only one `documentAdditions` task that also handles index creation.
 
 **Update an index** | `PUT` - `/indexes/:indexUid`
 


### PR DESCRIPTION
# Summary

The term `update` is not the best choice as it can be confused with `document` or `setting` updates. We have chosen to replace this term with `task`, which is more generic and better reflects the meaning of this API resource.

As an additional change, we have reworked the format of an update to make it more in line with our expectations of an API that is supposed to be easily understandable and developer-oriented.

The changes we will make to the response format of the `task` object lists will make it easier to add more functionality in a future iteration. See the Future Possibilities section for a brief overview.

Two new API endpoints are added. Although quite simple, they allow consulting the list of tasks or a specific task without being forced to know the related index.

## Summary Key Points

- The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
- Tasks are now also accessible as an independent resource of an index. `GET - /tasks`; `GET - /tasks/:taskUid`.
- The task `uid` is not incremented by index anymore. The sequence is generated globally.
- A `task_not_found` error is introduced.
-  The format of the `task` object is updated.
    - `updateId` becomes `uid`.
    - Attributes of an error appearing in a `failed` `task` are now contained in a dedicated `error` object.
    - `type` is no longer an object. It now becomes a string containing the values of its `name` field previously defined in the `type` object.
    - The possible values for the `type` field are reworked to be more clear and consistent with our naming rules.
    - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object. Previous `number` key is renamed `numberOfDocuments`.
    - An `indexUid` field is added to give information about the related index on which the task is performed.
    - `duration` format has been updated to express an `ISO 8601` duration.
    - `processed` status changes to `succeeded`.
    - `startedProcessingAt` is updated to `startedAt`.
    - `processedAt` is updated to `finishedAt`.
- `202 Accepted` requests previously returning an `updateId` are now returning a summarized `task` object.
- `MEILI_MAX_UDB_SIZE` env var is updated `MEILI_MAX_TASK_DB_SIZE`.
- `--max-udb-size` cli option is updated to `--max-task-db-size`.
- `task` object lists are now returned under a `results` array.
- Each operation on an index (creation, update, deletion) is now asynchronous and represented by a `task`.

# Motivation

The main motivation is to stabilize the current `update` resource to a version that conforms to our API convention and thus allows future evolutions on a more solid base. We would like to modify the name `update`, its format is also to be reviewed because some attributes are not immediately clear, either in the possible values or in the chosen names.