### PR TITLE
Add definitions of the missing behaviors for the sort specification

### DIFF
--- a/text/0055-sort.md
+++ b/text/0055-sort.md
@@ -2,7 +2,6 @@
 - Start Date: 2021-07-20
 - Specification PR: [#55](https://github.com/meilisearch/specifications/pull/55)
 - Discovery Issue: [#43](https://github.com/meilisearch/product/issues/43)
-- MeiliSearch Tracking-issues:
 
 # Sort
 
@@ -148,6 +147,10 @@ Request body
 #### **As an End-User, I want to specify a `sort` parameter at search time so that I can sort search result in ascending/descending order from document attributes, whether they are `numeric` or `string`.**
 
 - Introduce a `sort` parameter on GET/POST `/search` methods.
+
+> 💡 In the case where an attribute is specified as a sort criterion at search time and if this attribute is of a different type between several documents, the numeric type will always be favored first by the engine. This means that documents with numeric values for this attribute will be sorted before those with string values. This can lead to awkward sorting behavior, so the user should make sure to have the same type on the attribute he wants to sort on for all these documents.
+
+> 💡 In the case where an attribute is specified as a sort criterion at search time and does not exist on a document, the document will be placed at the end of the ranking rule sort.
 
 **GET Search /indexes/{indexUid}/search**
 
@@ -408,6 +411,8 @@ Note that if I change the `sort` parameter's value order, it changes the inner e
 - Add `sort` query/request parameter on `/search` resource. Support `string` and `number`. `string` can be sorted in lexicographical order.
 - Change custom ranking rule format. e.g. `asc(price)` become `price:asc`
 - Add a new error `invalid_sort` similar to `invalid_filter`.
+- The numeric type is preferred to the string type by the `sort` ranking rule. If an attribute has different types among the documents, those containing a numeric value will be placed before the documents containing a string value type.
+- A document not containing an attribute requested in the `sort` parameter will be placed last during the tie-breaking of the `sort` ranking-rule.
 
 ## 2. Technical details
 


### PR DESCRIPTION
- In the case where an attribute is specified as a sort criterion at search time and if this attribute is of a different type between several documents, the numeric type will always be favored first by the engine. This means that documents with numeric values for this attribute will be sorted before those with string values. This can lead to awkward sorting behavior, so the user should make sure to have the same type on the attribute he wants to sort on for all these documents.

- In the case where an attribute is specified as a sort criterion at search time and does not exist on a document, the document will be placed at the end of the ranking rule sort.