### PR TITLE
Add alternative message for reserved keyword and update invalid_criterion error definition

### DIFF
--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -242,7 +242,7 @@ This error is raised asynchronously when the user try to specify an invalid rank
     "message": ":rankingRule ranking rule is invalid. Valid ranking rules are Words, Typo, Sort, Proximity, Attribute, Exactness and custom ranking rules."
     "code": "invalid_ranking_rule"
     "type": "invalid_request"
-    "link": "https://docs.meilisearch.com/errors#invalid_field"
+    "link": "https://docs.meilisearch.com/errors#invalid_ranking_rule"
 ```
 
 - 🔴 Specifying an invalid ranking rule name raises an `invalid_ranking_rule` error. See `message` defined in the error definition part.

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -130,14 +130,15 @@ This error occurs when the `_geo` field of a document payload is not valid.
 
 ```json
 {
-    "message": "The _geo field is invalid. :syntaxErrorHelper.",
+    "message": "The document with the id: `:documentId` contains an invalid _geo field: :syntaxErrorHelper.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
 }
 ```
 
-- The `:syntaxErrorHelper` is inferred when a syntax error is encountered.
+- The `:documentId` is inferred when the message is generated.
+- The `:syntaxErrorHelper` is inferred when the message is generated.
 
 ---
 

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -235,7 +235,7 @@ The error is currently marked as an internal error thus the name is not explicit
 
 #### Context
 
-This error is raised asynchronously when the user try to specify an invalid ranking rule in the ranking rules setting.
+This error is raised asynchronously when the user tries to specify an invalid ranking rule in the ranking rules setting.
 
 #### Error Definition
 


### PR DESCRIPTION
## Summary Key Points

- Add an alternative message for `invalid_sort` and `invalid_filter` errors to handle reserved keywords.
- `invalid_criterion` is renamed to `invalid_ranking_rule` and add an alternative message to handle reserved keywords.
- Update `invalid_geo_field` error message.

Pinging @guimachiavelli for information sharing.