### PR TITLE
Add error at search time if the `sort` ranking rule is not specified in the ranking rules.

### DIFF
--- a/text/0055-sort.md
+++ b/text/0055-sort.md
@@ -39,7 +39,7 @@ We want to offer a simple and versatile solution for their needs.
 **GET settings** `/indexes/{indexUid}/settings`
 
 200 - Response with empty `sortableAttributes` (default case)
-```
+```json
 {
     ...,
     "sortableAttributes": []
@@ -48,7 +48,7 @@ We want to offer a simple and versatile solution for their needs.
 ```
 
 200 - Response with already configured `sortableAttributes`
-```
+```json
 {
     ...,
     "sortableAttributes": ["price", "released_date"]
@@ -61,7 +61,7 @@ We want to offer a simple and versatile solution for their needs.
 **POST settings** `/indexes/{indexUid}/settings`
 
 Request body
-```
+```json
 {
     ...,
 	"sortableAttributes": ["price", "released_date", "title"],
@@ -70,7 +70,7 @@ Request body
 ```
 
 202 Accepted - Response body
-```
+```json
 {
     "updateId": 7
 }
@@ -85,7 +85,7 @@ Request body
 💡 Resetting all settings will result to the default case e.g. `sortableAttributes: []`
 
 202 Accepted - Response body
-```
+```json
 {
     "updateId": 8
 }
@@ -94,12 +94,12 @@ Request body
 **GET settings/sortable-attributes** `/indexes/{indexUid}/settings/sortable-attributes`
 
 200 - Response body (Default case)
-```
+```json
 []
 ```
 
 200 - Response body with `sortableAttributes` already configured
-```
+```json
 [
     "price",
     "released_date"
@@ -121,7 +121,7 @@ Request body
 ```
 
 202 Accepted - Response body
-```
+```json
 {
     "updateId": 7
 }
@@ -136,7 +136,7 @@ Request body
 **DEL settings/sortable-attributes** `/indexes/{indexUid}/settings/sortable-attributes`
 
 202 Accepted - Response body
-```
+```json
 {
     "updateId": 8
 }
@@ -163,7 +163,7 @@ Request body
 `sort` - Array[String] - E.g.
 
 Request body
-```
+```json
 {
     ...,
     "sort": [
@@ -173,31 +173,51 @@ Request body
     ...
 }
 ```
+- 🔴 Sending a sort parameter while the `sort` ranking rule is not specified in the ranking rules settings will lead to a 400 Bad Request - **invalid_sort** error.
 
-🔴 Sending a value not set in `sortableAttribute` will lead to a 400 Bad Request - **invalid_sort** error.
-
-```
+```json
 {
-    "message": "attribute `title` is not sortable, available sortable attributes are: ..., ...",
+    "message": "The sort ranking rule must be specified in the ranking rules settings to use the sort parameter at search time.",
     "errorCode": "invalid_sort",
     "errorType": "invalid_request_error",
     "errorLink": "https://docs.meilisearch.com/errors#invalid_sort"
 }
 ```
 
-🔴 Sending a wrong formatted value will lead to a 400 Bad Request - **invalid_sort**.
+- 🔴 Sending a value not set in `sortableAttribute` will lead to a 400 Bad Request - **invalid_sort** error.
+
+```json
+{
+    "message": "Attribute :attribute is not sortable, available sortable attributes are: ..., ...",
+    "errorCode": "invalid_sort",
+    "errorType": "invalid_request_error",
+    "errorLink": "https://docs.meilisearch.com/errors#invalid_sort"
+}
+```
+- `:attribute` is inferred when the message is generated.
+
+- 🔴 Sending a wrong formatted value will lead to a 400 Bad Request - **invalid_sort**.
+
+```json
+{
+    "message": "Invalid syntax for the sort parameter: :syntaxErrorHelper.",
+    "errorCode": "invalid_sort",
+    "errorType": "invalid_request_error",
+    "errorLink": "https://docs.meilisearch.com/errors#invalid_sort"
+}
+```
+- `:syntaxErrorhelper` is inferred when the message is generated.
 
 We want to align the way custom ordering rules are written with the syntax of the `sort` search parameter.
 
 Current custom ranking rule definition syntax
-```
+```json
 [
-    "asc(title)",
-    ...
+    "asc(title)"
 ]
 ```
 become
-```
+```json
 [
     "title:asc"
 ]
@@ -206,7 +226,7 @@ become
 **Search example with `sort`**
 
 With this set of document
-```
+```json
 [
     {
         "id": 1,
@@ -234,7 +254,7 @@ With this set of document
 ```
 
 With this ranking rules definition
-```
+```json
 [
     "sort",
     "words",
@@ -246,7 +266,7 @@ With this ranking rules definition
 ```
 
 And with this `sortableAttributes` definition
-```
+```json
 [
     "price",
     "reviews_rating"
@@ -256,7 +276,7 @@ And with this `sortableAttributes` definition
 **POST Search**
 
 Request Body
-```
+```json
 {
     ...,
     "sort" = [
@@ -267,7 +287,7 @@ Request Body
 ```
 
 200 - Response
-```
+```json
 {
     "hits": [
         {
@@ -303,7 +323,7 @@ As we can see `sort` is the most important criterion in play according to the ra
 **GET settings/ranking-rules** `/indexes/{indexUid}/settings/ranking-rules`
 
 200 - Response body (Default case)
-```
+```json
 [
     "words",
     "typo",
@@ -317,7 +337,7 @@ As we can see `sort` is the most important criterion in play according to the ra
 **POST settings/ranking-rules**
 
 Request body
-```
+```json
 [
     "sort",
     "words",
@@ -329,7 +349,7 @@ Request body
 ```
 
 202 Accepted - Response body
-```
+```json
 {
     "updateId": 7
 }
@@ -343,7 +363,7 @@ e.g. Relevant Sort
 
 I want a relevant sort (sort on relevant items). I put sort at the latest level of my ranking rules.
 
-```
+```json
 [
   "typo",
   "words",
@@ -355,7 +375,7 @@ I want a relevant sort (sort on relevant items). I put sort at the latest level 
 ```
 
 At search time, if I use (knowing that price and reviews_rating have been set as sortable-attributes previously)
-```
+```json
 {
     "q": "Mac Book",
     "sort": [
@@ -367,7 +387,7 @@ At search time, if I use (knowing that price and reviews_rating have been set as
 
 Ranking rules can virtually be represented that way for this search request.
 
-```
+```json
 [
   "typo",
   "words",
@@ -381,7 +401,7 @@ Ranking rules can virtually be represented that way for this search request.
 
 Note that if I change the `sort` parameter's value order, it changes the inner element of the `sort` ranking rule.
 
-```
+```json
 {
     "q": "Mac Book",
     "sort": [
@@ -391,7 +411,7 @@ Note that if I change the `sort` parameter's value order, it changes the inner e
 }
 ```
 
-```
+```json
 [
   "typo",
   "words",


### PR DESCRIPTION
Added this case to guide the user if the `sort` ranking rule is not specified in the ranking rules.

