### PR TITLE
Put `sort` ranking rule in a position that promote relevancy by default

### DIFF
--- a/text/0055-sort.md
+++ b/text/0055-sort.md
@@ -51,7 +51,7 @@ We want to offer a simple and versatile solution for their needs.
 ```json
 {
     ...,
-    "sortableAttributes": ["price", "released_date"]
+    "sortableAttributes": ["price", "release_date"]
     ...
 }
 ```
@@ -64,7 +64,7 @@ Request body
 ```json
 {
     ...,
-	"sortableAttributes": ["price", "released_date", "title"],
+	"sortableAttributes": ["price", "release_date", "title"],
     ...
 }
 ```
@@ -102,7 +102,7 @@ Request body
 ```json
 [
     "price",
-    "released_date"
+    "release_date"
 ]
 ```
 
@@ -115,7 +115,7 @@ Request body
 ```
 [
     "price",
-    "released_date",
+    "release_date",
     "title"
 ]
 ```
@@ -154,7 +154,7 @@ Request body
 
 **GET Search /indexes/{indexUid}/search**
 
-`sort` - String - E.g. `sort="price:asc,released_date:desc"`
+`sort` - String - E.g. `sort="price:asc,release_date:desc"`
 
 > `:asc`
 
@@ -168,7 +168,7 @@ Request body
     ...,
     "sort": [
         "price:asc",
-        "released_date:desc"
+        "release_date:desc"
     ],
     ...
 }
@@ -256,9 +256,9 @@ With this set of document
 With this ranking rules definition
 ```json
 [
-    "sort",
-    "words",
+    "sort"
     "typo",
+    "words",
     "proximity",
     "attribute",
     "exactness"
@@ -279,7 +279,7 @@ Request Body
 ```json
 {
     ...,
-    "sort" = [
+    "sort": [
         "price:asc",
         "reviews_rating:desc"
     ]
@@ -327,9 +327,9 @@ As we can see `sort` is the most important criterion in play according to the ra
 [
     "words",
     "typo",
-    "sort",
     "proximity",
     "attribute",
+    "sort",
     "exactness"
 ]
 ```
@@ -399,7 +399,7 @@ Ranking rules can virtually be represented that way for this search request.
 ]
 ```
 
-Note that if I change the `sort` parameter's value order, it changes the inner element of the `sort` ranking rule.
+Note that if I change the `sort` search parameter's value order, it changes the inner element of the `sort` ranking rule.
 
 ```json
 {
@@ -427,7 +427,7 @@ Note that if I change the `sort` parameter's value order, it changes the inner e
 
 - Add `sortableAttributes` parameter in settings schema.
 - Add `sortable-attributes` API ressource.
-- Add a `sort` ranking rule at the third position by default.
+- Add the `sort` ranking rule after `attribute` ranking rule by default to promote relevant sort.
 - Add `sort` query/request parameter on `/search` resource. Support `string` and `number`. `string` can be sorted in lexicographical order.
 - Change custom ranking rule format. e.g. `asc(price)` become `price:asc`
 - Add a new error `invalid_sort` similar to `invalid_filter`.


### PR DESCRIPTION
### Summary Key Changes

- `sort` ranking rule is moved after the `attribute` ranking rule to promote a more relevant sort by default.