### PR TITLE
Raise `1000` positions limit to `65535` for document attribute

### DIFF
--- a/text/0077-words-position-limit.md
+++ b/text/0077-words-position-limit.md
@@ -24,7 +24,7 @@ n/a
 
 ## 2. Technical Aspects
 
-When MeiliSearch indexes a document, it indexes several words position per field until a limit is reached.
+When MeiliSearch indexes a document, it indexes several word positions per field until a limit is reached.
 
 It is important to note that the limit is not strictly related to the number of words. Indeed, soft separators are also counted as `1` position while hard separators are counted as `8` positions.
 


### PR DESCRIPTION
# Summary

The purpose of this specification is to remove the limit of 1000 positions per attribute.

## Summary Key points

- 1000 position limit per document field is now raised at 65535.

# Motivation

We've seen many users denormalizing fields into multiple fields to index all the words because of the initial limit. This change increases the limit to 65535 which should greatly reduce returns on this issue and reduce the changes to be made to the document schema in order to use MeiliSearch more quickly and easily.