### PR TITLE
GeoSearch — Support string type for `_geo` `lat` and `lng` fields

### DIFF
--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -47,6 +47,7 @@ According to our user feedback, the lack of a geosearch feature is mentioned as 
 
 > 💡 if `_geo` is found in the document payload, `lat` and `lng` are required.
 > 💡 `lat` and `lng` must be of float value.
+> 💡 `lat` and `lng` field type can be mixed. e.g. `lat` can be a string while `lng` is a number in the same `_geo` object.
 
 ##### **CSV Format**
 


### PR DESCRIPTION
Allows us to improve the user experience when using GeoSearch. 

When indexing the `_geo` field as a filterable or sortable attribute, MeiliSearch should be able to parse string or numeric values rather than raise an `invalid_geo_field` error.