### PR TITLE
Fix documentation of search `sort` query param

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -189,6 +189,9 @@ components:
 
         > warn
         > Attribute(s) used in `sort` should be declared as sortable attributes. See [Sorting](https://docs.meilisearch.com/reference/features/sorting.html).
+
+        > info
+        > _geoPoint({lat}, {long}) built-in sort rule can be used to sort documents around a geo point.
       example:
         - 'price:desc'
       title: sort
@@ -623,6 +626,7 @@ components:
 
         > warn
         > Attribute(s) used in `sort` should be declared as sortable attributes. See [Sorting](https://docs.meilisearch.com/reference/features/sorting.html).
+
         > info
         > _geoPoint({lat}, {long}) built-in sort rule can be used to sort documents around a geo point.
     filter:


### PR DESCRIPTION
It seems there's a missing empty line to differentiate two call-outs in the documentation of the `sort` query parameter of the `GET` search route.

Strangely enough, the `POST` search route doesn't have this `info` call-out maybe it's an oversight?

# Pull Request

## What does this PR do?

Fixes a documentation visual defect in the OpenAPI contract [here](https://bump.sh/doc/meilisearch#get-indexes-parameter-search-sort).