### PR TITLE
Accepts 0 documents payload on `POST`/`PUT`- `/documents`

### DIFF
--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -875,19 +875,6 @@ HTTP Code: `400 Bad Request`
 - The `:payloadType` is inferred when the message is generated. e.g. `json`, `ndjson`, `csv`
 - The `:syntaxErrorHelper` is inferred when the message is generated.
 
-#### Variant: Sending a valid but empty `[]`/`{}` payload on `POST`/`PUT` - `indexes/:indexUid/documents`.
-
-```json
-{
-    "message": "The `:payloadType` payload must contain at least one document.",
-    "code": "malformed_payload",
-    "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#malformed_payload"
-}
-```
-
-- The `:payloadType` is inferred when the message is generated. e.g. `json`, `csv`.
-
 ---
 
 # internal type


### PR DESCRIPTION
# Description

Following feedback on https://github.com/meilisearch/product/discussions/319. 

MeiliSearch does not return an error to guide the user anymore when a payload with 0 documents is sent for the routes `POST`- `PUT` `/documents`.

This is to facilitate the creation of an empty index and the use of message queues sending empty payloads to be indexed.

