### PR TITLE
Add telemetry node to get auto inferred identifiers during `Documents Added` and `Documents Updated` events

### DIFF
--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -1,6 +1,6 @@
 - Title: Anonymous Analytics Policy
 - Started At: 2021-04-16
-- Updated At: 2021-10-13
+- Updated At: 2022-01-12
 
 # Anonymous Analytics Policy
 
@@ -88,6 +88,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `pagination.max_limit`                  | Highest value given for the `limit` parameter in this batch | 60 | `Documents Searched POST`, `Documents Searched GET` |
 | `pagination.max_offset`                 | Highest value given for the `offset` parameter in this batch | 1000 | `Documents Searched POST`, `Documents Searched GET` |
 | `primary_key`                           | Value given for the `primaryKey` parameter if used, otherwise `null` | id | `Index Created`, `Index Updated`, `Documents Added`, `Documents Updated`|
+| `inferred`                              | Distribution of automatically inferred identifiers encountered in this batch, otherwise `null`. | ["movie_id", "pid"] | `Documents Added`, `Documents Updated` |
 | `payload_type`                          | All `payload_type` encountered in this batch | ["application/json", "text/plain", "application/x-ndjson"] | `Documents Added`, `Documents Updated` |
 | `index_creation`                        | `true` if a document addition or update request triggered index creation in this batch, otherwise `false` | true | `Documents Added`, `Documents Updated` |
 | `ranking_rules.sort_position`           | Position of the `sort` ranking rule | 5 | `Settings Updated`, `Ranking Rules Updated` |
@@ -209,6 +210,7 @@ This property allows us to gather essential information to better understand on 
 | user_agent    | Represents all the user-agents encountered on this endpoint in the aggregated event. | ["MeiliSearch Ruby (2.1)", "Ruby (3.0)"] |
 | payload_type | Represents all the payload_type encountered on this endpoint in the aggregated event as a set. `application/json`/ `application/x-ndjson`/ `text/plain` or any non-supported content-type. | [`text/plain`, `application/json`] |
 | primary_key   | Represents all the `primaryKey` query parameters encountered in the aggregated event as a set, otherwise `null`. | ["id"] |
+| inferred | Represents all the inferred identifiers chosen by the MeiliSearch automatic id detection encountered in the aggregated event as a set., otherwise `null`. | ["movie_id", "pid"] |
 | index_creation | Does an index creation happened among all requests in the aggregated event? | `false`|
 
 ---
@@ -222,6 +224,7 @@ This property allows us to gather essential information to better understand on 
 | user_agent    | Represents all the user-agents encountered on this endpoint in the aggregated event. | ["MeiliSearch Ruby (2.1)", "Ruby (3.0)"] |
 | payload_type | Represents all the payload_type encountered on this endpoint in the aggregated event as a set. `application/json`/ `application/x-ndjson`/ `text/plain` or any non-supported content-type. | [`text/plain`, `application/json`] |
 | primary_key   | Represents all the `primaryKey` query parameters encountered in the aggregated event as a set, otherwise `null`. | ["id"] |
+| inferred | Represents all the inferred identifiers chosen by the automatic id detection encountered in the aggregated event as a set, otherwise `null`. | ["movie_id", "pid"] |
 | index_creation | Does an index creation happened among all requests in the aggregated event? | `false`|
 
 ---


### PR DESCRIPTION
# Objectives

Determine if this automatic inference chooses `id` most of the time. 

Given this information, we may propose a new way to determine identifiers and thus remove the automatic inference that takes the first field containing `id` during the first indexing. We already observed that the usage of `primaryKey` is mostly used to specify `id` or `_id`. 

It may turn out that this automatic inference causes more problems than it facilitates access to MeiliSearch, we want to acknowledge that fact.