### PR TITLE
Introduce invalid_index_uid error in API key spec

### DIFF
--- a/text/0085-api-keys.md
+++ b/text/0085-api-keys.md
@@ -238,10 +238,11 @@ Only the master key allows managing the API keys.
 - 🔴 Omitting `actions` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
 - 🔴 Omitting `indexes` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
 - 🔴 Omitting `expiresAt` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
-- 🔴 Sending an invalid value for the `actions` field returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
-- 🔴 Sending an invalid value for the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending an invalid value for the `actions` field (not an array of strings) returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
+- 🔴 Sending an invalid value for the `indexes` field (not an array of strings) returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
 - 🔴 Sending an invalid value for the `expiresAt` field returns an [invalid_api_key_expires_at](0061-error-format-and-definitions.md#invalid_api_key_expires_at) error.
 - 🔴 Sending an invalid value for the `description` field returns an [invalid_api_key_description](0061-error-format-and-definitions.md#invalid_api_key_description) error.
+- 🔴 Sending a value that is not a valid `index` (e.g. regarding the index uid format) in the `indexes` field returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
 
 ---
 
@@ -350,10 +351,11 @@ Only the master key allows managing the API keys.
 - 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
 - 🔴 Sending a different payload type than the Content-Type header returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
 - 🔴 Sending an invalid json format returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
-- 🔴 Sending an invalid value for the `actions` field returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
-- 🔴 Sending an invalid value for the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending an invalid value for the `actions` field (not an array of strings) returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
+- 🔴 Sending an invalid value for the `indexes` field (not an array of strings) returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
 - 🔴 Sending an invalid value for the `expiresAt` field returns an [invalid_api_key_expires_at](0061-error-format-and-definitions.md#invalid_api_key_expires_at) error.
 - 🔴 Sending an invalid value for the `description` field returns an [invalid_api_key_description](0061-error-format-and-definitions.md#invalid_api_key_description) error.
+- 🔴 Sending a value that is not a valid `index` (e.g. regarding the index uid format) in the `indexes` field returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
 
 ---
 


### PR DESCRIPTION
Following https://github.com/meilisearch/meilisearch/issues/2158

I did not update the part regarding the actions (return an error when the action is invalid) because
- it's not the scope of the issue here: https://github.com/meilisearch/meilisearch/issues/2158. Since the issue is a good first issue I don't want to make the contributors lost
- it add a message variant for `invalid_api_indexes` error
- this is not required by any user, so not a priority :) 