### PR TITLE
Keys API - Add a variant message when an index uid format is invalid for the `indexes` field. 

### DIFF
--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -195,6 +195,19 @@ HTTP Code: `400 Bad Request`
 
 - The `:value` is inferred when the message is generated.
 
+#### Variant: Sending an invalid index uid format in `indexes` field.
+
+```json
+{
+    "message": "`uid` is not a valid index uid. Index uid can be an integer or a string containing only alphanumeric characters, hyphens (-) and underscores (_).",
+    "code": "invalid_api_key_indexes",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_api_key_indexes"
+}
+```
+
+- The `:uid` is inferred when the message is generated.
+
 ---
 
 ## invalid_api_key_expires_at

--- a/text/0085-api-keys.md
+++ b/text/0085-api-keys.md
@@ -358,7 +358,6 @@ Only the master key allows managing the API keys.
 - 🔴 Sending an invalid value for the `expiresAt` field returns an [invalid_api_key_expires_at](0061-error-format-and-definitions.md#invalid_api_key_expires_at) error.
 - 🔴 Sending an invalid value for the `description` field returns an [invalid_api_key_description](0061-error-format-and-definitions.md#invalid_api_key_description) error.
 
-
 ---
 
 #### **As `Anna 👩`, I want to list the API Keys**

--- a/text/0085-api-keys.md
+++ b/text/0085-api-keys.md
@@ -238,10 +238,12 @@ Only the master key allows managing the API keys.
 - 🔴 Omitting `actions` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
 - 🔴 Omitting `indexes` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
 - 🔴 Omitting `expiresAt` field from the payload returns a [missing_parameter](0061-error-format-and-definitions.md#missing_parameter) error.
-- 🔴 Sending an invalid value for the `actions` field returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
-- 🔴 Sending an invalid value for the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending an invalid value for the `actions` field (not an array of strings) returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
+- 🔴 Sending an invalid value for the `indexes` field (not an array of strings) returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending a value that is not a valid `index` (e.g. regarding the index uid format) in the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) with a variant error message similar to [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error message.
 - 🔴 Sending an invalid value for the `expiresAt` field returns an [invalid_api_key_expires_at](0061-error-format-and-definitions.md#invalid_api_key_expires_at) error.
 - 🔴 Sending an invalid value for the `description` field returns an [invalid_api_key_description](0061-error-format-and-definitions.md#invalid_api_key_description) error.
+
 
 ---
 
@@ -350,10 +352,12 @@ Only the master key allows managing the API keys.
 - 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
 - 🔴 Sending a different payload type than the Content-Type header returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
 - 🔴 Sending an invalid json format returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
-- 🔴 Sending an invalid value for the `actions` field returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
-- 🔴 Sending an invalid value for the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending an invalid value for the `actions` field (not an array of strings) returns an [invalid_api_key_actions](0061-error-format-and-definitions.md#invalid_api_key_actions) error.
+- 🔴 Sending an invalid value for the `indexes` field (not an array of strings) returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) error.
+- 🔴 Sending a value that is not a valid `index` (e.g. regarding the index uid format) in the `indexes` field returns an [invalid_api_key_indexes](0061-error-format-and-definitions.md#invalid_api_key_indexes) with a variant error message similar to [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error message.
 - 🔴 Sending an invalid value for the `expiresAt` field returns an [invalid_api_key_expires_at](0061-error-format-and-definitions.md#invalid_api_key_expires_at) error.
 - 🔴 Sending an invalid value for the `description` field returns an [invalid_api_key_description](0061-error-format-and-definitions.md#invalid_api_key_description) error.
+
 
 ---
 


### PR DESCRIPTION
Use the `invalid_index_uid` error message as a variant for `invalid_api_key_indexes` error when an invalid index uid is set into the API Key `indexes` field.

### Related issue

https://github.com/meilisearch/meilisearch/issues/2158