### PR TITLE
Tasks API - Seek/Keyset based pagination

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -29,10 +29,14 @@ components:
       type: integer
       description: Limit given for the query. If limit is not provided as a query parameter, this parameter displays the default limit value.
       example: 10
-    after:
+    from:
       type: integer
-      description: Represents identifier to fetch the next slice of the results. The first item identifier for the next slice starts at `after+1`.
+      description: The first task uid returned.
       example: 999
+    next:
+      type: integer
+      description: Represents the value to send in `from` to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order.
+      example: 989
     timestamp:
       type: string
       description: An `RFC 3339` format for date/time/duration.
@@ -699,6 +703,12 @@ components:
       schema:
         type: number
         default: 0
+    from:
+      name: from
+      in: query
+      description: Fetch the next set of results from the given uid.
+      schema:
+        type: number
     q:
       name: q
       in: query
@@ -2892,12 +2902,15 @@ paths:
                       $ref: '#/components/schemas/task'
                   limit:
                     $ref: '#/components/schemas/limit'
-                  after:
-                    $ref: '#/components/schemas/after'
+                  from:
+                    $ref: '#/components/schemas/from'
+                  next:
+                    $ref: '#/components/schemas/next'
                 required:
                   - results
                   - limit
-                  - after
+                  - from
+                  - next
               examples:
                 Example:
                   value:
@@ -2932,9 +2945,12 @@ paths:
                         startedAt: '2021-01-01T09:38:02.000000Z'
                         finishedAt: '2021-01-01T09:38:07.000000Z'
                     limit: 2
-                    after: null
+                    from: 1
+                    next: null
       operationId: tasks.list
-      parameters: []
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/from'
       security:
         - apiKey: []
   '/tasks/:taskUid':

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -25,6 +25,14 @@ servers:
     description: 'https://example.meilisearch.com:7700'
 components:
   schemas:
+    limit:
+      type: integer
+      description: Limit given for the query. If limit is not provided as a query parameter, this parameter displays the default limit value.
+      example: 10
+    after:
+      type: integer
+      description: Represents identifier to fetch the next slice of the results. The first item identifier for the next slice starts at `after+1`.
+      example: 999
     timestamp:
       type: string
       description: An `RFC 3339` format for date/time/duration.
@@ -2882,6 +2890,14 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/task'
+                  limit:
+                    $ref: '#/components/schemas/limit'
+                  after:
+                    $ref: '#/components/schemas/after'
+                required:
+                  - results
+                  - limit
+                  - after
               examples:
                 Example:
                   value:
@@ -2915,6 +2931,8 @@ paths:
                         enqueuedAt: '2021-01-01T09:38:00.000000Z'
                         startedAt: '2021-01-01T09:38:02.000000Z'
                         finishedAt: '2021-01-01T09:38:07.000000Z'
+                    limit: 2
+                    after: null
       operationId: tasks.list
       parameters: []
       security:

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -593,14 +593,15 @@ The main drawback of this type of pagination is that it does not navigate within
 | field | type | description                          |
 |-------|------|--------------------------------------|
 | limit | integer  | Default `20`. |
-| after | integer - nullable  | Represents the query parameter to send to fetch the next slice of the results. The first item for the next slice starts at `after+1`. When the returned value is null, it means that all the data have been browsed in the given order. |
+| from | integer | The first task uid returned |
+| next | integer - nullable  | Represents the query parameter to send to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order. |
 
 ##### 9.3 GET query parameters
 
 | field | type | required | description  |
 |-------|------|----------|--------------|
 | limit | integer  | No       | Default `20`. Limit on the number of tasks to be returned. |
-| after | integer  | No       | Limit results to tasks with uids greater/lower than the specified uid. |
+| from | integer  | No       | Limit results to tasks with uids equal to and lower than this uid. |
 
 ##### 9.4 Usage examples
 
@@ -630,13 +631,14 @@ This part demonstrates keyset paging in action on `/tasks`, but it should be equ
         }
     ],
     "limit": 20,
-    "after": 1330
+    "from": 1350,
+    "next": 1329
 }
 ```
 
 **Request the next slice of `tasks` items with a limit of `50` tasks**
 
-`GET` - `/tasks?after=1330&limit=50`
+`GET` - `/tasks?from=1329&limit=50`
 
 ```json
 {
@@ -656,13 +658,14 @@ This part demonstrates keyset paging in action on `/tasks`, but it should be equ
         }
     ],
     "limit": 50,
-    "after": 1279
+    "from": 1329,
+    "next": 1278
 }
 ```
 
 **End of cursor pagination**
 
-`GET` - `/tasks?after=20`
+`GET` - `/tasks?from=20`
 
 ```json
 {
@@ -681,23 +684,23 @@ This part demonstrates keyset paging in action on `/tasks`, but it should be equ
             ...,
         }
     ],
-    "limit": 10,
-    "after": null
+    "limit": 20,
+    "from": 20,
+    "next": null
 }
 ```
 
-- 💡 `after` response parameter is null because there are no more `tasks` to fetch. It means that the response represents the last slice of results for the given resource list.
+- 💡 `next` response parameter is null because there are no more `tasks` to fetch. It means that the response represents the last slice of results for the given resource list.
 
-##### 9.5 Behaviors for `limit` and `after` query parameters
+##### 9.5 Behaviors for `limit` and `from` query parameters
 
 ###### 9.5.1 `limit`
 
 - If `limit` is not set, the default value is chosen.
-- If `limit` is not an integer, the default value is chosen.
 
-###### 9.5.2 `after`
+###### 9.5.2 `from`
 
-- If `after` is set with an out of bounds task `uid`, the response returns an empty `results` array and `after` is set to `null`.
+- If `from` is set with an out of bounds task `uid`, the response returns the tasks that are the nearest to the specified uid, the `next` field is set to the next page. It will be equivalent to call the `/tasks` route without any parameter.
 
 ## 2. Technical details
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -570,7 +570,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 #### 9. Paginate `task` resource lists
 
-The API endpoints `/tasks` and `indexes/{indexUid}/tasks` are browsable using a keyset based pagination.
+The API endpoint `/tasks` is browsable using a keyset-based pagination.
 
 ##### 9.1 Why a Seek/Keyset based pagination?
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -572,7 +572,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 The API endpoints `/tasks` and `indexes/{indexUid}/tasks` are browsable using a keyset based pagination.
 
-##### 9.1 Why a keyset based pagination?
+##### 9.1 Why a Seek/Keyset based pagination?
 
 Keyset-based pagination is more appropriate when the data can grow or shrink quickly in terms of magnitude.
 
@@ -580,7 +580,7 @@ Keyset-based pagination is more appropriate when the data can grow or shrink qui
 
 The performance is better than the not-so-good but old pagination with `offset`/`limit`.
 
-Cursor pagination keeps the results consistent between each page as the data evolves. It avoids the [Page Drift effect](https://use-the-index-luke.com/sql/partial-results/fetch-next-page), especially when the data is sorted from the most recent to the oldest.
+Seek/Keyset pagination keeps the results consistent between each page as the data evolves. It avoids the [Page Drift effect](https://use-the-index-luke.com/sql/partial-results/fetch-next-page), especially when the data is sorted from the most recent to the oldest.
 
 Moreover, the performance is superior to traditional pagination since the computational complexity remains constant to reach the identifier marking the beginning of the new slice to be returned from a hash table.
 
@@ -594,7 +594,7 @@ The main drawback of this type of pagination is that it does not navigate within
 |-------|------|--------------------------------------|
 | limit | integer  | Default `20`. |
 | from | integer | The first task uid returned |
-| next | integer - nullable  | Represents the query parameter to send to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order. |
+| next | integer - nullable  | Represents the value to send in `from` to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order. |
 
 ##### 9.3 GET query parameters
 
@@ -663,7 +663,7 @@ This part demonstrates keyset paging in action on `/tasks`, but it should be equ
 }
 ```
 
-**End of cursor pagination**
+**End of seek/keyset pagination**
 
 `GET` - `/tasks?from=20`
 
@@ -701,6 +701,11 @@ This part demonstrates keyset paging in action on `/tasks`, but it should be equ
 ###### 9.5.2 `from`
 
 - If `from` is set with an out of bounds task `uid`, the response returns the tasks that are the nearest to the specified uid, the `next` field is set to the next page. It will be equivalent to call the `/tasks` route without any parameter.
+
+###### 9.5.3 Errors
+
+- 🔴 Sending a value with a different type than `Integer` for `limit` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
+- 🔴 Sending a value with a different type than `Integer` for `from` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
 ## 2. Technical details
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -570,11 +570,11 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 #### 9. Paginate `task` resource lists
 
-The API endpoints `/tasks` and `indexes/{indexUid}/tasks` are browsable using a cursor based pagination.
+The API endpoints `/tasks` and `indexes/{indexUid}/tasks` are browsable using a keyset based pagination.
 
-##### 9.1 Why a cursor based pagination?
+##### 9.1 Why a keyset based pagination?
 
-As seen in the [Rest API Format Convention](https://github.com/meilisearch/product/issues/44#issuecomment-895888679), cursor-based pagination is more appropriate when the data can grow or shrink quickly in terms of magnitude.
+Keyset-based pagination is more appropriate when the data can grow or shrink quickly in terms of magnitude.
 
 ###### 9.1.1 Pros
 
@@ -592,19 +592,19 @@ The main drawback of this type of pagination is that it does not navigate within
 
 | field | type | description                          |
 |-------|------|--------------------------------------|
-| limit | integer  | Default `30`. |
+| limit | integer  | Default `20`. |
 | after | integer - nullable  | Represents the query parameter to send to fetch the next slice of the results. The first item for the next slice starts at `after+1`. When the returned value is null, it means that all the data have been browsed in the given order. |
 
 ##### 9.3 GET query parameters
 
 | field | type | required | description  |
 |-------|------|----------|--------------|
-| limit | integer  | No       | Default `30`. Limit on the number of tasks to be returned, between `1` and `100`. |
+| limit | integer  | No       | Default `20`. Limit on the number of tasks to be returned. |
 | after | integer  | No       | Limit results to tasks with uids greater/lower than the specified uid. |
 
 ##### 9.4 Usage examples
 
-This part demonstrates cursor paging on `/tasks`, but it should be equivalent for `indexes/:uid/tasks`. Although the uids can be "holey" on the `/indexes/:uid/tasks` endpoint if several indexes are managed within the instance. The items uid remains sorted sequentially and can be used to navigate a list of `tasks` objects.
+This part demonstrates keyset paging in action on `/tasks`, but it should be equivalent for `indexes/:uid/tasks`. Although the uids can be "holey" on the `/indexes/:uid/tasks` endpoint if several indexes are managed within the instance. The items uid remains sorted sequentially and can be used to navigate a list of `tasks` objects.
 
 ---
 
@@ -693,7 +693,6 @@ This part demonstrates cursor paging on `/tasks`, but it should be equivalent fo
 ###### 9.5.1 `limit`
 
 - If `limit` is not set, the default value is chosen.
-- If `limit` is defined and that the given value is not between the minimum `1` and the maximum `100`, minimum and maximum value included, the default value `30` is chosen.
 - If `limit` is not an integer, the default value is chosen.
 
 ###### 9.5.2 `after`

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -693,7 +693,7 @@ This part demonstrates cursor paging on `/tasks`, but it should be equivalent fo
 ###### 9.5.1 `limit`
 
 - If `limit` is not set, the default value is chosen.
-- If `limit` is set and it is not between the minimum and maximum values, the default value is chosen.
+- If `limit` is defined and that the given value is not between the minimum `1` and the maximum `100`, minimum and maximum value included, the default value `30` is chosen.
 - If `limit` is not an integer, the default value is chosen.
 
 ###### 9.5.2 `after`

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -711,11 +711,10 @@ This part demonstrates cursor paging on `/tasks`, but it should be equivalent fo
 
 ## 3. Future Possibilities
 
-- Add a pagination system for on `/tasks` and `indexes/:indexUid/tasks` lists.
 - Add enhanced filtering capabilities.
 - Simplify `documentAddition` and `documentPartial` type and elaborate on `details` metadata.
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.
 - Reconsider existence of `/indexes/:indexUid/tasks/:taskUid` route since it is similar to `/tasks/:taskUid`.
 - Add an archived state for old `tasks`.
-- Indicate the `API Key` identity that added a `task`. It should not permits to
+- Indicate the `API Key` identity that added a `task`.

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -605,7 +605,7 @@ The main drawback of this type of pagination is that it does not navigate within
 
 ##### 9.4 Usage examples
 
-This part demonstrates keyset paging in action on `/tasks`, but it should be equivalent for `indexes/:uid/tasks`. Although the uids can be "holey" on the `/indexes/:uid/tasks` endpoint if several indexes are managed within the instance. The items uid remains sorted sequentially and can be used to navigate a list of `tasks` objects.
+This part demonstrates keyset paging in action on `/tasks`. The items `uid` remains sorted sequentially and can be used to navigate a list of `tasks` objects.
 
 ---
 


### PR DESCRIPTION
🤖 [API Diff](https://github.com/meilisearch/specifications/pull/115#issuecomment-1129027036)

## Summary

`task` resource lists now support seek pagination, allowing users to browse multiple sets of `task` items.

### Summary Key Points

- Add `limit`, `from`, `next` response attributes to task list response.
- It only concerns the `/tasks` endpoint. `/indexes/:uid/tasks` endpoint is removed by https://github.com/meilisearch/specifications/pull/116.

## Motivation

Following the specification aiming to stabilize the `task` API resource, we want to give Meilisearch capabilities to adapt to many use-cases, thus involving unpredictable orders of magnitude regarding `task` growth over time.

This feature should be usable by both solo developers and technical teams.

The objectives set during the discovery's exploration phase for the pagination of the task lists are:

- Performance should remain nearly constant, regardless of task volume.
- The results must be browsable in a consistent way between each call to the API, no matter how much the number of tasks is increased or reduced while the navigation is happening.
- Do not reinvent the wheel and therefore facilitate its implementation by selecting a proven paging interface.
- A subsidiary, but critical objective, is to feed our API guideline to respond quickly to such needs in the future within the company. By proposing a proven solution, we can build faster with confidence.