### PR TITLE
Tasks API - Filter tasks list by `type`/`status`/`indexUid`

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -875,6 +875,10 @@ components:
                 type: string
                 description: The status of the task
                 example: enqueued
+              type:
+                type: string
+                description: The type of the task
+                example: indexCreation
               enqueuedAt:
                 $ref: '#/components/schemas/timestamp'
                 description: Represent the date and time as `RFC 3339` format when the task has been enqueued

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -283,7 +283,7 @@ components:
           indexUid: movies
           batchUid: 0
           status: succeeded
-          type: documentAddition
+          type: documentAdditionOrUpdate
           details:
             receivedDocuments: 10
             indexedDocuments: 10
@@ -314,30 +314,28 @@ components:
           type: string
           description: The type of the task
           enum:
-            - documentAddition
-            - documentPartial
+            - documentAdditionOrUpdate
             - documentDeletion
             - indexCreation
             - indexUpdate
             - indexDeletion
             - settingsUpdate
-            - clearAll
         details:
           type: object
           description: Details information of the task payload.
           properties:
             receivedDocuments:
               type: integer
-              description: Number of documents received for documentAddition or documentPartial task.
+              description: Number of documents received for documentAdditionOrUpdate task.
             indexedDocuments:
               type: integer
-              description: Number of documents finally indexed for documentAddition or documentPartial task or if batched, in the batchUid.
+              description: Number of documents finally indexed for documentAdditionOrUpdate task or if batched, in the batchUid.
             receivedDocumentsIds:
               type: integer
               description: Number of document ids received for documentDeletion task.
             deletedDocuments:
               type: integer
-              description: 'Number of documents finally deleted for documentDeletion, indexDeletion or clearAll task.'
+              description: 'Number of documents finally deleted for documentDeletion and indexDeletion tasks.'
             primaryKey:
               type: string
               description: Value for the primaryKey field encountered if any for indexCreation or indexUpdate task.
@@ -2840,7 +2838,7 @@ paths:
                         indexUid: movies
                         batchUid: 1
                         status: succeeded
-                        type: documentAddition
+                        type: documentAdditionOrUpdate
                         details:
                           receivedDocuments: 79000
                           indexedDocuments: 79000
@@ -2852,7 +2850,7 @@ paths:
                         indexUid: movies_Review
                         batchUid: 0
                         status: failed
-                        type: documentAddition
+                        type: documentAdditionOrUpdate
                         details:
                           receivedDocuments: 67493
                           indexedDocuments: 0
@@ -2897,7 +2895,7 @@ paths:
                     indexUid: movies
                     batchUid: 1
                     status: succeeded
-                    type: documentAddition
+                    type: documentAdditionOrUpdate
                     details:
                       receivedDocuments: 79000
                       indexedDocuments: 79000

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -681,6 +681,27 @@ components:
       required: true
       schema:
         type: number
+    taskIndexUid:
+      name: indexUid
+      in: path
+      description: Permits to filter tasks by their related index. By default, when `indexUid` query parameter is not set, the tasks of all the indexes are returned. It is possible to specify several indexes by separating them with the `,` character.
+      required: false
+      schema:
+        type: string
+    taskType:
+      name: type
+      in: path
+      description: Permits to filter tasks by their related type. By default, when `type` query parameter is not set, all task types are returned. It's possible to specify several types by separating them with the `,` character.
+      required: false
+      schema:
+        type: string
+    taskStatus:
+      name: status
+      in: path
+      description: Permits to filter tasks by their status. By default, when `status` query parameter is not set, all task statuses are returned. It's possible to specify several types by separating them with the `,` character.
+      required: false
+      schema:
+        type: string
     primaryKey:
       name: primaryKey
       in: query
@@ -2535,106 +2556,6 @@ paths:
           description: Not Found
     parameters:
       - $ref: '#/components/parameters/indexUid'
-  '/indexes/{indexUid}/tasks':
-    get:
-      operationId: indexes.tasks.list
-      summary: Get all tasks of an index
-      description: |
-        Get all [tasks](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html) of an [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
-      tags:
-        - Tasks
-      security:
-        - apiKey: []
-      responses:
-        '200':
-          description: Ok
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  results:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/task'
-              examples:
-                Example:
-                  value:
-                    results:
-                      - uid: 1
-                        indexUid: movies,
-                        batchUid: 1
-                        status: succeeded
-                        type: documentAddition
-                        details:
-                          receivedDocuments: 79000
-                          indexedDocuments: 79000
-                        duration: PT2S
-                        enqueuedAt: '2021-01-01T09:39:00.000000Z'
-                        startedAt: '2021-01-01T09:39:01.000000Z'
-                        finishedAt: '2021-01-01T09:39:02.000000Z'
-                      - uid: 0
-                        indexUid: movies
-                        batchUid: 0
-                        status: failed
-                        type: documentAddition
-                        details:
-                          receivedDocuments: 67493
-                          indexedDocuments: 0
-                        error:
-                          message: 'Document does not have a `:primaryKey` attribute: `:documentRepresentation`.'
-                          code: missing_document_id
-                          type: invalid_request
-                          link: 'https://docs.meilisearch.com/errors#missing_document_id'
-                        duration: PT5S
-                        enqueuedAt: '2021-01-01T09:38:00.000000Z'
-                        startedAt: '2021-01-01T09:38:02.000000Z'
-                        finishedAt: '2021-01-01T09:38:07.000000Z'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          description: Not Found
-    parameters:
-      - $ref: '#/components/parameters/indexUid'
-  '/indexes/{indexUid}/tasks/{taskUid}':
-    get:
-      operationId: indexes.tasks.get
-      summary: Get a task of an index
-      description: |
-        Get a [task](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html) of an [index](https://docs.meilisearch.com/learn/core_concepts/indexes.html).
-      tags:
-        - Tasks
-      security:
-        - apiKey: []
-      responses:
-        '200':
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/task'
-              examples:
-                Example:
-                  value:
-                    uid: 1
-                    indexUid: movies
-                    batchUid: 1
-                    status: succeeded
-                    type: documentAddition
-                    details:
-                      receivedDocuments: 79000
-                      indexedDocuments: 79000
-                    duration: PT1S
-                    enqueuedAt: '2021-01-01T09:39:00.000000Z'
-                    startedAt: '2021-01-01T09:39:01.000000Z'
-                    finishedAt: '2021-01-01T09:39:02.000000Z'
-        '401':
-          $ref: '#/components/responses/401'
-        '404':
-          description: Not Found
-    parameters:
-      - $ref: '#/components/parameters/indexUid'
-      - $ref: '#/components/parameters/taskUid'
   /keys:
     get:
       operationId: keys.list
@@ -2951,6 +2872,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/from'
+        - $ref: '#/components/parameters/taskIndexUid'
+        - $ref: '#/components/parameters/taskStatus'
+        - $ref: '#/components/parameters/taskType'
       security:
         - apiKey: []
   '/tasks/:taskUid':

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -57,7 +57,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | TypoTolerance Updated | Occurs when typo tolerance settings are updated via `POST` - `/indexes/:indexUid/settings/typo-tolerance`. |
 | Dump Created | Occurs when a dump is created via `POST` - `/dumps`. |
 | Tasks Seen | Occurs when tasks are fetched globally via `GET` - `/tasks`. |
-| Index Tasks Seen | Occurs when tasks are filtered by index via `GET` - `/indexes/:indexUid/tasks`. |
+
 ----
 
 #### Summarized Metrics/Events table
@@ -128,8 +128,11 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `typo_tolerance.disable_on_words`                   | `true` if at least one value is defined | `false` | `Settings Updated`,  `TypoTolerance Updated` |
 | `typo_tolerance.min_word_size_for_typos.one_typo` | The defined value for `minWordSizeForTypos.oneTypo` property | `5` | `Settings Updated`, `TypoTolerance Updated` |
 | `typo_tolerance.min_word_size_for_typos.two_typos`| The defined value for `minWordSizeForTypos.twoTypos` property | `9` | `Settings Updated`, `TypoTolerance Updated` |
-| `per_task_uid`                          | `true` if an uid is used to fetch a particular task resource, otherwise `false` | true | `Tasks Seen`, `Index Tasks Seen` |
-|
+| `per_task_uid`                          | `true` if an uid is used to fetch a particular task resource, otherwise `false` | true | `Tasks Seen` |
+| `filtered_by_index_uid`                 | `true` if `GET /tasks` endpoint is filered by `indexUid`, otherwise `false` | false | `Tasks Seen` |
+| `filtered_by_type`                      | `true` if `GET /tasks` endpoint is filered by `type`, otherwise `false` | false | `Tasks Seen` |
+| `filtered_by_status`                    | `true` if `GET /tasks` endpoint is filered by `status`, otherwise `false` | false | `Tasks Seen` |
+
 
 ----
 
@@ -367,13 +370,9 @@ This property allows us to gather essential information to better understand on 
 |---------------|-------------|---------|
 | user_agent    | Represents the user-agent encountered on this call. | `["Meilisearch Ruby (v2.1)", "Ruby (3.0)"]` |
 | per_task_uid  | `true` if an uid is used to fetch a particular task resource, otherwise `false` | `true` |
-
-## `Index Tasks Seen`
-
-| Property name | Description | Example |
-|---------------|-------------|---------|
-| user_agent    | Represents the user-agent encountered on this call. | `["Meilisearch Ruby (v2.1)", "Ruby (3.0)"]` |
-| per_task_uid  | `true` if an uid is used to fetch a particular task resource, otherwise `false` | `true` |
+| filtered_by_index_uid | `true` if `GET /tasks` endpoint is filered by `indexUid`, otherwise `false` | `false` |
+| filtered_by_type | `true` if `GET /tasks` endpoint is filered by `type`, otherwise `false` | `false` |
+| filtered_by_status | `true` if `GET /tasks` endpoint is filered by `status`, otherwise `false` | `false` |
 
 ---
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -700,6 +700,5 @@ n/a
 
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.
-- Reconsider existence of `/indexes/:indexUid/tasks/:taskUid` route since it is similar to `/tasks/:taskUid`.
 - Add an archived state for old `tasks`.
 - Indicate the `API Key` identity that added a `task`.

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -1,9 +1,4 @@
-- Title: Tasks API
-- Start Date: 2021-08-13
-- Specification PR: [#60](https://github.com/meilisearch/specifications/pull/60)
-- Discovery Issue: [#48](https://github.com/meilisearch/product/issues/48)
-
-# Refashion Updates APIs
+# Tasks API
 
 ## 1. Functional Specification
 
@@ -393,81 +388,6 @@ Allows users to get a detailed `task` object retrieved by the `uid` field regard
 
 ---
 
-**Get all tasks of an index** | `GET` - `/indexes/{indexUid}/tasks`
-
-##### Goals
-
-Allows users to list tasks of a particular index.
-
-`200` - Response body - `/indexes/movies/tasks`
-
-```json
-{
-    "results": [
-        {
-            "uid": 1,
-            "indexUid": "movies",
-            "batchUid": 1,
-            "status": "enqueued",
-            "type": "documentAddition",
-            "duration": null,
-            "enqueuedAt": "2021-08-12T10:00:00.000000Z",
-            "startedAt": null,
-            "finishedAt": null
-        },
-        {
-            "uid": 0,
-            "indexUid": "movies",
-            "batchUid": 0,
-            "status": "succeeded",
-            "type": "documentAddition",
-            "details": {
-                "receivedDocuments": 100,
-                "indexedDocuments": 100
-            },
-            "duration": "PT16S",
-            "enqueuedAt": "2021-08-11T09:25:53.000000Z",
-            "startedAt": "2021-08-11T10:03:00.000000Z",
-            "finishedAt": "2021-08-11T10:03:16.000000Z"
-        }
-    ]
-}
-```
-
-##### Errors
-
-- 🔴 If a master key is configured on the server-side but missing from the client in the `X-MEILI-API-KEY` header, the API returns a `401 Unauthorized` - `missing_authorization_header` error.
-- 🔴 If a master key is sent by the client but does not match the value configured on the server-side, the API returns a `403 Forbidden` - `invalid_api_key`.
-- 🔴 If the index does not exist, the API returns a `404 Not Found` - `index_not_found` error.
-
----
-
-**Get a task of an index** | `GET` - `/indexes/{indexUid}/tasks/{tasksUid}`
-
-`200` - Response body - `/indexes/movies/tasks/1`
-
-```json
-{
-
-    "uid": 1,
-    "indexUid": "movies",
-    "batchUid": 1,
-    "status": "enqueued",
-    "type": "documentAddition",
-    "duration": null,
-    "enqueuedAt": "2021-08-12T10:00:00.000000Z",
-    "startedAt": null,
-    "finishedAt": null
-}
-```
-
-##### Errors
-
-- 🔴 If a master key is configured on the server-side but missing from the client in the `X-MEILI-API-KEY` header, the API returns a `401 Unauthorized` - `missing_authorization_header` error.
-- 🔴 If a master key is sent by the client but does not match the value configured on the server-side, the API returns a `403 Forbidden` - `invalid_api_key`.
-- 🔴 If the index does not exist, the API returns a `404 Not Found` - `index_not_found` error.
-- 🔴 If the task does not exist, the API returns a `404 Not Found` - `task_not_found` error.
-
 #### 6. `task_not_found` error
 
 ##### Context
@@ -707,8 +627,6 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
 - 🔴 Sending a value with a different type than `Integer` for `limit` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 - 🔴 Sending a value with a different type than `Integer` for `from` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
----
-
 #### 10. Filtering task resources
 
 The `/tasks` endpoint is filterable by `indexUid`, `type` and `status` query parameters.
@@ -895,16 +813,10 @@ If no results match the filters. A response is returned with an empty `results` 
 
 ## 2. Technical details
 
-### I. Measuring
-
-- Number of call on `indexes/:indexUid/tasks` per instance
-- Number of call on `indexes/:indexUid/tasks/:taskUid` per instance
-- Number of call on `tasks` per instance
-- Number of call on `tasks/:taskUid` per instance
+n/a
 
 ## 3. Future Possibilities
 
-- Add enhanced filtering capabilities.
 - Simplify `documentAddition` and `documentPartial` type and elaborate on `details` metadata.
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -50,30 +50,30 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 > This fully qualified version appears as a response object on `task` dedicated endpoints.
 
-| field   | type    | description                     |
-|---------|---------|---------------------------------|
-| uid      | integer | Unique sequential identifier           |
-| indexUid | string | Unique index identifier |
-| batchUid | integer | Identify in which batch a task has been grouped by auto-batching. It corresponds to the first task uid grouped within a batch. See [auto-batching specification](0096-auto-batching.md) |
-| status  | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                |
-| type    | string  | Type of the task. Possible values are `indexCreation`, `indexUpdate`, `indexDeletion`, `documentAddition`, `documentPartial`, `documentDeletion`, `settingsUpdate`, `clearAll` |
-| details | object |  Details information for a task payload. See Task Details part. |
-| error | object | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61|
- | duration | string | Total elapsed time the engine was in processing state expressed as an `ISO-8601` duration format. Times below the second can be expressed with the `.` notation, e.g., `PT0.5S` to express `500ms`. Default is set to `null`.   |
-| enqueuedAt | string | Represent the date and time as `RFC 3339` format when the task has been enqueued |
-| startedAt | string | Represent the date and time as `RFC 3339` format when the task has been dequeued and started to be processed. Default is set to `null`|
-| finishedAt | string | Represent the date and time as `RFC 3339` format when the task has `failed` or `succeeded`. Default is set to `null` |
+| field      | type    | description                                                                                                                                                                                                                   |
+|------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| uid        | integer | Unique sequential identifier                                                                                                                                                                                                  |
+| indexUid   | string  | Unique index identifier                                                                                                                                                                                                       |
+| batchUid   | integer | Identify in which batch a task has been grouped by auto-batching. It corresponds to the first task uid grouped within a batch. See [auto-batching specification](0096-auto-batching.md)                                       |
+| status     | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                                                                                                                       |
+| type       | string  | Type of the task. Possible values are `indexCreation`, `indexUpdate`, `indexDeletion`, `documentAddition`, `documentPartial`, `documentDeletion`, `settingsUpdate`, `clearAll`                                                |
+| details    | object  | Details information for a task payload. See Task Details part.                                                                                                                                                                |
+| error      | object  | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61                                                                                |
+| duration   | string  | Total elapsed time the engine was in processing state expressed as an `ISO-8601` duration format. Times below the second can be expressed with the `.` notation, e.g., `PT0.5S` to express `500ms`. Default is set to `null`. |
+| enqueuedAt | string  | Represent the date and time as `RFC 3339` format when the task has been enqueued                                                                                                                                              |
+| startedAt  | string  | Represent the date and time as `RFC 3339` format when the task has been dequeued and started to be processed. Default is set to `null`                                                                                        |
+| finishedAt | string  | Represent the date and time as `RFC 3339` format when the task has `failed` or `succeeded`. Default is set to `null`                                                                                                          |
 
 > 💡 The order of the fields must be returned in this order.
 
 ##### Summarized `task` Object for `202 Accepted`
 
-| field      | type    | description                     |
-|------------|---------|---------------------------------|
-| taskUid    | integer | Unique sequential identifier |
-| indexUid   | string | Unique index identifier |
-| status     | string  | Status of the task. Value is `enqueued` |
-| enqueuedAt | string | Represent the date and time as `RFC 3339` format when the task has been enqueued |
+| field      | type    | description                                                                      |
+|------------|---------|----------------------------------------------------------------------------------|
+| taskUid    | integer | Unique sequential identifier                                                     |
+| indexUid   | string  | Unique index identifier                                                          |
+| status     | string  | Status of the task. Value is `enqueued`                                          |
+| enqueuedAt | string  | Represent the date and time as `RFC 3339` format when the task has been enqueued |
 
 
 > 💡 The order of the fields must be returned in this order.
@@ -93,16 +93,16 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 #### 3. `type` field enum
 
-| old        | new           |
-|------------|---------------|
-|  -         | indexCreation |
-|  -         | indexUpdate   |
-|  -         | indexDeletion |
-| DocumentsAddition | documentAddition  |
-| DocumentsPartial | documentPartial  |
-| DocumentsDeletion  | documentDeletion |
-| Settings     | settingsUpdate |
-| ClearAll | clearAll |
+| old               | new              |
+|-------------------|------------------|
+| -                 | indexCreation    |
+| -                 | indexUpdate      |
+| -                 | indexDeletion    |
+| DocumentsAddition | documentAddition |
+| DocumentsPartial  | documentPartial  |
+| DocumentsDeletion | documentDeletion |
+| Settings          | settingsUpdate   |
+| ClearAll          | clearAll         |
 
 > 👍 Type values follow a `camelCase` naming convention.
 >
@@ -112,64 +112,64 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 ##### documentAddition
 
-| name     | description |
-| -------- | --------    |
-| receivedDocuments | Number of documents received. |
+| name              | description                          |
+|-------------------|--------------------------------------|
+| receivedDocuments | Number of documents received.        |
 | indexedDocuments  | Number of documents finally indexed. |
 
 
 ##### documentPartial
 
-| name     | description |
-| -------- | --------    |
-| receivedDocuments | Number of documents received. |
+| name              | description                          |
+|-------------------|--------------------------------------|
+| receivedDocuments | Number of documents received.        |
 | indexedDocuments  | Number of documents finally indexed. |
 
 
 ##### documentDeletion
 
-| name     | description |
-| -------- | --------    |
-| receivedDocumentIds | Number of document ids received.  |
+| name                | description                          |
+|---------------------|--------------------------------------|
+| receivedDocumentIds | Number of document ids received.     |
 | deletedDocuments    | Number of documents finally deleted. |
 
 ##### indexCreation
 
-| name     | description |
-| -------- | --------    |
-| primaryKey  | Value for the `primaryKey` field into the POST index payload. `null` if no `primaryKey` has been specified at the time of the index creation. |
+| name       | description                                                                                                                                   |
+|------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| primaryKey | Value for the `primaryKey` field into the POST index payload. `null` if no `primaryKey` has been specified at the time of the index creation. |
 
 
 ##### indexUpdate
 
-| name     | description |
-| -------- | --------    |
+| name       | description                                                                                                                                |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | primaryKey | Value for the `primaryKey` field into the PUT index payload. `null` if no `primaryKey` has been specified at the time of the index update. |
 
 ##### indexDeletion
 
-| name     | description |
-| -------- | --------    |
-| deletedDocuments    | Number of deleted documents. Should be all documents contained in the deleted index. |
+| name             | description                                                                          |
+|------------------|--------------------------------------------------------------------------------------|
+| deletedDocuments | Number of deleted documents. Should be all documents contained in the deleted index. |
 
 ##### clearAll
 
-| name     | description |
-| -------- | --------    |
-| deletedDocuments    | Number of deleted documents. Should be all documents contained in the cleared index. |
+| name             | description                                                                          |
+|------------------|--------------------------------------------------------------------------------------|
+| deletedDocuments | Number of deleted documents. Should be all documents contained in the cleared index. |
 
 ##### settingsUpdate
 
-| name     | description |
-| -------- | --------    |
-| rankingRules     | `rankingRules` payload array |
+| name                 | description                          |
+|----------------------|--------------------------------------|
+| rankingRules         | `rankingRules` payload array         |
 | searchableAttributes | `searchableAttributes` payload array |
 | filterableAttributes | `filterableAttributes` payload array |
-| sortableAttributes | `sortableAttributes` payload array | 
-| stopWords | `stopWords` payload array |
-| synonyms  | `synonyms` payload object |
-| distinctAttribute | `distrinctAttribute` payload string |
-| displayedAttributes | `displayedAttributes` payload array |
+| sortableAttributes   | `sortableAttributes` payload array   |
+| stopWords            | `stopWords` payload array            |
+| synonyms             | `synonyms` payload object            |
+| distinctAttribute    | `distrinctAttribute` payload string  |
+| displayedAttributes  | `displayedAttributes` payload array  |
 
 #### 5. Examples
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -41,6 +41,7 @@ As writing is asynchronous for most of Meilisearch's operations, this API makes 
 | taskUid    | integer | Unique sequential identifier                                                     |
 | indexUid   | string  | Unique index identifier                                                          |
 | status     | string  | Status of the task. Value is `enqueued`                                          |
+| type       | string  | Type of the task.                                                                |
 | enqueuedAt | string  | Represent the date and time as `RFC 3339` format when the task has been enqueued |
 
 
@@ -238,7 +239,7 @@ e.g. A summarized `task` object in a `202 Accepted` HTTP response returned at in
     "taskUid": 0,
     "indexUid": "movies",
     "status": "enqueued",
-    "type": "createIndex",
+    "type": "indexCreation",
     "enqueuedAt": "2021-08-11T09:25:53.000000Z"
 }
 ```

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -707,6 +707,192 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
 - 🔴 Sending a value with a different type than `Integer` for `limit` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 - 🔴 Sending a value with a different type than `Integer` for `from` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
+---
+
+#### 10. Filtering task resources
+
+The `/tasks` endpoint is filterable by `indexUid`, `type` and `status` query parameters.
+
+##### 10.1. Query parameters definition
+
+| parameter | type   | required | description                                                                                                                                                                                                                             |
+|-----------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| indexUid  | string | No       | Permits to filter tasks by their related index. By default, when `indexUid` query parameter is not set, the tasks of all the indexes are returned. It is possible to specify several indexes by separating them with the `,` character. |
+| status    | string | No       | Permits to filter tasks by their status. By default, when `status` query parameter is not set, all task statuses are returned. It's possible to specify several types by separating them with the `,` character.                        |
+| type      | string | No       | Permits to filter tasks by their related type. By default, when `type` query parameter is not set, all task types are returned. It's possible to specify several types by separating them with the `,` character.                       |
+
+##### 10.2. Usages examples
+
+This part demonstrates filtering on `/tasks`.
+
+---
+
+**No filtering**
+
+`GET` - `/tasks`
+
+```json
+{
+    "results": [
+        {
+            "uid": 1350,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        },
+        ...,
+        {
+            "uid": 1330,
+            "indexUid": "movies_reviews",
+            "status": "succeeded",
+            "type": "documentDeletion",
+            ...
+        }
+    ],
+    ...
+}
+```
+
+**Filter `tasks` that have a `failed` `status`**
+
+`GET` - `/tasks?status=failed`
+
+```json
+{
+    "results": [
+        {
+            "uid": 1350,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        },
+        ...,
+        {
+            "uid": 1279,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "settingsUpdate",
+            ...,
+        }
+    ],
+    ...
+}
+```
+
+**Filter `tasks` that are of `documentAdditionOrUpdate` type**
+
+`GET` - `/tasks?type=documentAdditionOrUpdate`
+
+```json
+{
+    "results": [
+        {
+            "uid": 1350,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        },
+        ...,
+        {
+            "uid": 1343,
+            "indexUid": "movies",
+            "type": "succeeded",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        }
+    ],
+    ...
+}
+```
+
+**Filter `tasks` that are of `documentAdditionOrUpdate` type and have a `failed` status**
+
+`GET` - `/tasks?type=documentAdditionOrUpdate&status=failed`
+
+```json
+{
+    "results": [
+        {
+            "uid": 1350,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        },
+        ...,
+        {
+            "uid": 1346,
+            "indexUid": "movies",
+            "status": "failed",
+            "type": "documentAdditionOrUpdate",
+            ...,
+        }
+    ],
+    ...
+}
+```
+
+- 💡 Filters can be used together. The two parameters are cumulated and a `AND` operation is performed between the two filters. An OR operation between filters is not supported.
+- `type` and `status` query parameters can be read as is `type=documentsAdditionOrUpdate AND status=failed`.
+
+**Filter `tasks` by an non-existent `indexUid`**
+
+`GET` - `/tasks?indexUid=aaaaa`
+
+```json
+{
+    "results": [],
+    ...
+}
+```
+
+- If the `indexUid` parameter value contains an inexistent index, it returns an empty `results` array.
+
+---
+
+##### 10.3. Behaviors for `indexUid`, `status` and `type` query parameters.
+
+###### 10.3.1. `indexUid`
+
+- Type: String
+- Required: False
+- Default: `*`
+
+`indexUid` is **case-sensitive**.
+
+###### 10.3.2. `status`
+
+- Type: String
+- Required: False
+- Default: `*`
+
+`status ` is **case-insensitive**.
+
+- 🔴 If the `status` parameter value is not consistent with one of the task statuses, an [`invalid_task_status`](0061-error-format-and-definitions.md#invalidtaskstatus) error is returned.
+
+###### 10.3.3. `type`
+
+- Type: String
+- Required: False
+- Default: `*`
+
+`type` is **case-insensitive**.
+
+- 🔴 If the `type` parameter value is not consistent with one of the task types, an [`invalid_task_type`](0061-error-format-and-definitions.md#invalidtasktype) error is returned.
+
+###### 10.3.4. Select multiple values for the same filter
+
+It is possible to specify multiple values for a filter using the `,` character.
+
+For example, to select the `enqueued` and `processing` tasks of the `movies` and `movie_reviews` indexes, it is possible to express it like this: `/tasks?indexUid=movies,movie_reviews&status=enqueued,processing`
+
+##### 10.4. Empty `results`
+
+If no results match the filters. A response is returned with an empty `results` array.
+
 ## 2. Technical details
 
 ### I. Measuring

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -4,43 +4,11 @@
 
 ### I. Summary
 
-The term `update` is not the best choice as it can be confused with document updates or `settings`. We have chosen to replace this term with `task`, which is more generic and better reflects the meaning of this API resource.
-
-As an additional change, we have reworked the format of an update to make it more in line with our expectations of an API that is supposed to be easily understandable and developer-oriented.
-
-Changing the format of `task` object lists makes adding more functionality in a future iteration easier. See the Future Possibilities section for a brief overview.
-
-The specification adds two new API endpoints. Although quite simple, they allow consulting the list of tasks or a specific task without being forced to know the related index.
-
-The specification makes any writing operation on an index asynchronous to serve consistency and facilitate future evolutions.
-
-#### Summary Key Points
-
-- The `update` resource is renamed `task`. The names of existing API routes are also changed to reflect this change.
-- Tasks are now also accessible as an independent resource of an index. `GET - /tasks`; `GET - /tasks/:taskUid`
-- The task `uid` is not incremented by index anymore. The sequence is generated globally.
-- A `task_not_found` error is introduced.
-- The format of the `task` object is updated.
-    - `updateId` becomes `uid`.
-    - Attributes of an error appearing in a `failed` `task` are now contained in a dedicated `error` object.
-    - `type` is no longer an object. It now becomes a string containing the values of its `name` field previously defined in the `type` object.
-    - The possible values for the `type` field are reworked to be more clear and consistent with our naming rules.
-    - A `details` object is added to contain specific information related to a `task` payload that was previously displayed in the `type` nested object.
-    - An `indexUid` field is added to give information about the related index on which the task is performed.
-    - `duration` format has been updated to express an `ISO 8601` duration.
-    - `processed` status changes to `succeeded`.
-    - `startedProcessingAt` is updated to `startedAt`.
-    - `processedAt` is updated to `finishedAt`.
-- `202 Accepted` requests previously returning an `updateId` are now returning a summarized `task` object.
-- `MEILI_MAX_UDB_SIZE` env var is updated `MEILI_MAX_TASK_DB_SIZE`.
-- `--max-udb-size` cli option is updated to `--max-task-db-size`.
-- `task` object lists are now returned under a `results` array.
-- Each operation on an index (creation, update, deletion) is now asynchronous and represented by a `task`.
-
+This specification describes the API endpoints for viewing asynchronous tasks.
 
 ### II. Motivation
 
-The motivation is to stabilize the current `update` resource to a version that conforms to our API convention, thus developing future evolutions on a more solid base. We want to modify the name `update`, the format is also changed because some attributes are not immediately explicit, either in the possible values or in the chosen names.
+As writing is asynchronous for most of Meilisearch's operations, this API makes it possible to track the progress of asynchronous tasks, to know and understand why a task failed and also serves as consulting the history of operations that happened.
 
 ### III. Explanation
 
@@ -54,11 +22,11 @@ The motivation is to stabilize the current `update` resource to a version that c
 |------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | uid        | integer | Unique sequential identifier                                                                                                                                                                                                  |
 | indexUid   | string  | Unique index identifier                                                                                                                                                                                                       |
-| batchUid   | integer | Identify in which batch a task has been grouped by auto-batching. It corresponds to the first task uid grouped within a batch. See [auto-batching specification](0096-auto-batching.md)                                       |
+| batchUid   | integer | Identify in which batch a task has been grouped by auto-batching. It corresponds to the first task uid grouped within a batch. See [0096-auto-batching.md](0096-auto-batching.md)                                             |
 | status     | string  | Status of the task. Possible values are `enqueued`, `processing`, `succeeded`, `failed`                                                                                                                                       |
-| type       | string  | Type of the task. Possible values are `indexCreation`, `indexUpdate`, `indexDeletion`, `documentAddition`, `documentPartial`, `documentDeletion`, `settingsUpdate`, `clearAll`                                                |
+| type       | string  | Type of the task. Possible values are `indexCreation`, `indexUpdate`, `indexDeletion`, `documentAdditionOrUpdate`, `documentDeletion`, `settingsUpdate`                                                                       |
 | details    | object  | Details information for a task payload. See Task Details part.                                                                                                                                                                |
-| error      | object  | Error object containing error details and context when a task has a `failed` status. See https://github.com/meilisearch/specifications/pull/61                                                                                |
+| error      | object  | Error object containing error details and context when a task has a `failed` status. See [0061-error-format-and-definitions.md](0061-error-format-and-definitions.md)                                                         |
 | duration   | string  | Total elapsed time the engine was in processing state expressed as an `ISO-8601` duration format. Times below the second can be expressed with the `.` notation, e.g., `PT0.5S` to express `500ms`. Default is set to `null`. |
 | enqueuedAt | string  | Represent the date and time as `RFC 3339` format when the task has been enqueued                                                                                                                                              |
 | startedAt  | string  | Represent the date and time as `RFC 3339` format when the task has been dequeued and started to be processed. Default is set to `null`                                                                                        |
@@ -82,49 +50,34 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 #### 2. `status` field enum
 
-| old        | new           |
-|------------|---------------|
-| enqueued   | -             |
-| processing | -             |
-| processed  | **succeeded** |
-| failed     | -             |
-
-> 👍 Better semantic differentiation between `processing` and `processed`. The final status of a *processed* task is `succeeded` or `failed`.
+| label      |
+|------------|
+| enqueued   |
+| processing |
+| succeeded  |
+| failed     |
 
 #### 3. `type` field enum
 
-| old               | new              |
-|-------------------|------------------|
-| -                 | indexCreation    |
-| -                 | indexUpdate      |
-| -                 | indexDeletion    |
-| DocumentsAddition | documentAddition |
-| DocumentsPartial  | documentPartial  |
-| DocumentsDeletion | documentDeletion |
-| Settings          | settingsUpdate   |
-| ClearAll          | clearAll         |
+| label                    |
+|--------------------------|
+| indexCreation            |
+| indexUpdate              |
+| indexDeletion            |
+| documentAdditionOrUpdate |
+| documentDeletion         |
+| settingsUpdate           |
 
 > 👍 Type values follow a `camelCase` naming convention.
->
-> 💡 `Settings` is updated to be more precise with the name `settingsUpdate`.
 
 #### 4. `details` field object
 
-##### documentAddition
+##### documentAdditionOrUpdate
 
 | name              | description                          |
 |-------------------|--------------------------------------|
 | receivedDocuments | Number of documents received.        |
 | indexedDocuments  | Number of documents finally indexed. |
-
-
-##### documentPartial
-
-| name              | description                          |
-|-------------------|--------------------------------------|
-| receivedDocuments | Number of documents received.        |
-| indexedDocuments  | Number of documents finally indexed. |
-
 
 ##### documentDeletion
 
@@ -151,12 +104,6 @@ The motivation is to stabilize the current `update` resource to a version that c
 | name             | description                                                                          |
 |------------------|--------------------------------------------------------------------------------------|
 | deletedDocuments | Number of deleted documents. Should be all documents contained in the deleted index. |
-
-##### clearAll
-
-| name             | description                                                                          |
-|------------------|--------------------------------------------------------------------------------------|
-| deletedDocuments | Number of deleted documents. Should be all documents contained in the cleared index. |
 
 ##### settingsUpdate
 
@@ -316,7 +263,7 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
             "indexUid": "movies_reviews",
             "batchUid": 1,
             "status": "enqueued",
-            "type": "documentAddition",
+            "type": "documentAdditionOrUpdate",
             "duration": null,
             "enqueuedAt": "2021-08-12T10:00:00.000000Z",
             "startedProcessingAt": null,
@@ -327,7 +274,7 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
             "indexUid": "movies",
             "batchUid": 0,
             "status": "succeeded",
-            "type": "documentAddition",
+            "type": "documentAdditionOrUpdate",
             "details": {
                 "receivedDocuments": 100,
                 "indexedDocuments": 100
@@ -353,8 +300,10 @@ Allows users to list tasks globally regardless of the indexes involved. Particul
 
 ##### Errors
 
-- 🔴 If a master key is configured on the server-side but missing from the client in the `X-MEILI-API-KEY` header, the API returns a `401 Unauthorized` - `missing_authorization_header` error.
-- 🔴 If a master key is sent by the client but does not match the value configured on the server-side, the API returns a `403 Forbidden` - `invalid_api_key`.
+The auth layer can return the following errors if Meilisearch is secured (a master-key is defined).
+
+- 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
+- 🔴 Accessing this route with a key that does not have the required permissions (i.e. other than the master-key) returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 
 ---
 
@@ -372,7 +321,7 @@ Allows users to get a detailed `task` object retrieved by the `uid` field regard
     "indexUid": "movies",
     "batchUid": 1,
     "status": "enqueued",
-    "type": "documentAddition",
+    "type": "documentAdditionOrUpdate",
     "duration": null,
     "enqueuedAt": "2021-08-12T10:00:00.000000Z",
     "startedAt": null,
@@ -382,9 +331,12 @@ Allows users to get a detailed `task` object retrieved by the `uid` field regard
 
 ##### Errors
 
-- 🔴 If a master key is configured on the server-side but missing from the client in the `X-MEILI-API-KEY` header, the API returns a `401 Unauthorized` - `missing_authorization_header` error.
-- 🔴 If a master key is sent by the client but does not match the value configured on the server-side, the API returns a `403 Forbidden` - `invalid_api_key`.
 - 🔴 If the task does not exist, the API returns a `404 Not Found` - `task_not_found` error.
+
+The auth layer can return the following errors if Meilisearch is secured (a master-key is defined).
+
+- 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
+- 🔴 Accessing this route with a key that does not have the required permissions (i.e. other than the master-key) returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 
 ---
 
@@ -409,84 +361,13 @@ HTTP Code: `404 Not Found`
 
 - The `:taskUid` is inferred when the message is generated.
 
-#### 7. `MEILI_MAX_UDB_SIZE` env var and `--max-udb-size` cli option
+#### 7. `MEILI_MAX_TASK_DB_SIZE` env var and `--max-task-db-size` CLI option
 
-As the notion of `update` no longer exists. The acronym `UDB` is changed by `TASK_DB`.
-
-- `MEILI_MAX_UDB_SIZE` env var is updated to `MEILI_MAX_TASK_DB_SIZE`.
-- `--max-udb-size` cli option is updated to `--max-task-db-size`.
+See [0119-instance-options](0119-instance-options.md##3312-max-taskdb-size)
 
 #### 8. Asynchronous Write Operations on Index resource
 
-To consolidate the writing behavior between an index and document modifications, configuration changes of settings, the creation, modification, and deletion of an index resource are now asynchronous.
-
-Initially, the index creation, update, and deletion operations were synchronous, which could cause problems like race conditions.
-
-For example, when updating documents on an index while an index is being deleted synchronously in parallel. It also improves the consistency for the understanding of writes within a MeiliSearch index among an identical behavior.
-
-This structure allows us to facilitate communications and write propagations in a high availability context in the future.
-
-The main change in the API is that the routes response described below now becomes a `202 Accepted` response with the summarized task response payload.
-
-Errors are now part of the `task` as for other asynchronous operations.
-
-New task types are also added for these operations. `indexCreation`, `indexUpdate`, and `indexDeletion`.
-
-**Create an index** | `POST` - `/indexes`
-
-```json
-{
-    "uid": "movies"
-}
-```
-
-`202` - Accepted Response body
-
-```json
-{
-    "taskUid": 0,
-    "indexUid": "movies",
-    "status": "enqueued",
-    "type": "indexCreation",
-    "enqueuedAt": "2021-08-12T10:00:00.000000Z"
-}
-```
-
-- 💡 Automatic index creation using the `/indexes/:indexToCreate/documents` route generates only one `documentAdditions` task that also handles index creation.
-
-**Update an index** | `PUT` - `/indexes/:indexUid`
-
-```json
-{
-    "primaryKey": "uid"
-}
-```
-
-`202` - Accepted Response body
-
-```json
-{
-    "taskUid": 1,
-    "indexUid": "movies",
-    "status": "enqueued",
-    "type": "indexUpdate",
-    "enqueuedAt": "2021-08-12T10:00:00.000000Z"
-}
-```
-
-**Delete an index** | `DELETE` - `/indexes/:indexUid`
-
-`202` - Accepted Response body
-
-```json
-{
-    "taskUid": 1,
-    "indexUid": "movies",
-    "status": "enqueued",
-    "type": "indexDeletion",
-    "enqueuedAt": "2021-08-12T10:00:00.000000Z"
-}
-```
+- 💡 Automatic index creation using the `/indexes/:indexToCreate/documents` route generates a `documentAdditionOrUpdate` task that also handles index creation.
 
 #### 9. Paginate `task` resource lists
 
@@ -539,14 +420,14 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
         {
             "uid": 1350,
             "indexUid": "movies",
-            "type": "documentAddition",
+            "type": "documentAdditionOrUpdate",
             ...,
         },
         ...,
         {
             "uid": 1330,
             "indexUid": "movies_reviews",
-            "type": "documentAddition",
+            "type": "documentAdditionOrUpdate",
             ...,
         }
     ],
@@ -566,7 +447,7 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
         {
             "uid": 1329,
             "indexUid": "movies",
-            "type": "documentAddition",
+            "type": "documentAdditionOrUpdate",
             ...,
         },
         ...,
@@ -593,14 +474,14 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
         {
             "uid": 19,
             "indexUid": "movies",
-            "type": "documentsAddition",
+            "type": "documentsAdditionOrUdpdate",
             ...,
         },
         ...,
         {
             "uid": 0,
             "indexUid": "movies",
-            "type": "documentsAddition",
+            "type": "documentsAdditionOrUpdate",
             ...,
         }
     ],
@@ -817,7 +698,6 @@ n/a
 
 ## 3. Future Possibilities
 
-- Simplify `documentAddition` and `documentPartial` type and elaborate on `details` metadata.
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.
 - Reconsider existence of `/indexes/:indexUid/tasks/:taskUid` route since it is similar to `/tasks/:taskUid`.

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -790,7 +790,7 @@ HTTP Code: `400 Bad Request`
 
 ```json
 {
-    "message": "`:status` is invalid. Available task statuses are: `:taskStatuses`.",
+    "message": "Task status `:status` is invalid. Available task statuses are: `:taskStatuses`.",
     "code": "invalid_task_status",
     "type": "invalid_request",
     "link":"https://docs.meilisearch.com/errors#invalid_task_status"
@@ -814,7 +814,7 @@ HTTP Code: `400 Bad Request`
 
 ```json
 {
-    "message": "`:type` is invalid. Available task types are: `:taskTypes`.",
+    "message": "Task type `:type` is invalid. Available task types are: `:taskTypes`.",
     "code": "invalid_task_type",
     "type": "invalid_request",
     "link":"https://docs.meilisearch.com/errors#invalid_task_type"

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -778,6 +778,54 @@ HTTP Code: `404 Not Found`
 
 ---
 
+## invalid_task_status
+
+### Context
+
+This error happens when a requested task status is invalid.
+
+#### Error Definition
+
+HTTP Code: `400 Bad Request`
+
+```json
+{
+    "message": "`:status` is invalid. Available task statuses are: `:taskStatuses`.",
+    "code": "invalid_task_status",
+    "type": "invalid_request",
+    "link":"https://docs.meilisearch.com/errors#invalid_task_status"
+}
+```
+
+- The `:status` is inferred when the message is generated.
+- The `:taskStatuses` is inferred when the message is generated.
+
+---
+
+## invalid_task_type
+
+### Context
+
+This error happens when a requested task type is invalid.
+
+### Error Definition
+
+HTTP Code: `400 Bad Request`
+
+```json
+{
+    "message": "`:type` is invalid. Available task types are: `:taskTypes`.",
+    "code": "invalid_task_type",
+    "type": "invalid_request",
+    "link":"https://docs.meilisearch.com/errors#invalid_task_type"
+}
+```
+
+- The `:type` is inferred when the message is generated.
+- The `:taskTypes` is inferred when the message is generated.
+
+---
+
 ## api_key_not_found
 
 `Synchronous`


### PR DESCRIPTION
🤖  [API Diff](https://github.com/meilisearch/specifications/pull/116#issuecomment-1105255632)

# Summary

Add filtering capabilities to the `tasks` endpoints to facilitate the management of an instance and its indexes, or a specific index.

This first iteration adds filters on the `status`, `type` and `indexUid` attributes of the `task` API resource.

## Changes

- Add filtering capabilities on `type`, `status` and `indexUid` for `GET` `task` lists endpoints.
- It is possible to specify several values for a filter using the `,` character. e.g. `?status=enqueued,processing`
- Between two different filters, an AND operation is applied. e.g. `?status=enqueued&type=indexCreation` is equivalent to `status=enqueued AND type = indexCreation`
- `GET /indexes/:indexUid/tasks` is removed
    - It can be replaced by `GET /tasks?indexUid=:indexUid`
- `GET /indexes/:indexUid/tasks/:taskUid` is removed
    - It's already replaced by `GET /tasks/:taskUid`
- Task types `documentPartial` and `documentAddition` are renamed `documentAdditionOrUpdate`
- Task type `clearAll` is renamed `documentDeletion`

### Telemetry

- `Index Tasks Seen` event is removed.
- Add `filtered_by_index_uid` boolean property for `Tasks Seen` event.
- Add `filtered_by_type` boolean property for `Tasks Seen` event.
- Add `filtered_by_status`boolean property for `Tasks Seen` event.

# Motivation

Following the specification aiming to stabilize the `task` API resource, we want to give users the capability to refine the lists of task according to several criteria to find precise information more quickly.
