### PR TITLE
Update spec template according to our current usage

### DIFF
--- a/text/0000-specification-template.md
+++ b/text/0000-specification-template.md
@@ -6,6 +6,6 @@
 
 ## 3. Functional Specification
 
-## 4. Technical Aspects
+## 4. Technical Details
 
 ## 5. Future Possibilities

--- a/text/0000-specification-template.md
+++ b/text/0000-specification-template.md
@@ -1,5 +1,3 @@
-- Title:
-
 # Title
 
 ## 1. Summary

--- a/text/0000-specification-template.md
+++ b/text/0000-specification-template.md
@@ -1,6 +1,4 @@
 - Title:
-- Start Date:
-- Specification PR:
 
 # Title
 

--- a/text/0000-specification-template.md
+++ b/text/0000-specification-template.md
@@ -1,21 +1,15 @@
 - Title:
 - Start Date:
 - Specification PR:
-- MeiliSearch Tracking-issues:
-
-> ❗️ The MeiliSearch Tracking-issues field is edited by delivery teams for listing any related issues that need to be done to fully implement this specification.
 
 # Title
 
-## 1. Functional Specification
+## 1. Summary
 
-### I. Summary
-### II. Motivation
-### III. Additional Materials
-### IV. Explanation
-### V. Impact on Documentation
-### VI. Impact on SDKs
+## 2. Movtivation
 
-## 2. Technical Aspects
+## 3. Functional Specification
 
-## 3. Future Possibilities
+## 4. Technical Aspects
+
+## 5. Future Possibilities


### PR DESCRIPTION
I update the template of the specs according to our current usage
- I remove the Meilisearch tracking issue part since sometimes multiples issues are related (with the improvements of the spec for example). However, if this is something you want to keep back in the process, please let me know
- I simplified the titles so that it's more adapted to what we do at the moment.

Since we are still learning about managing specs, I think this is important to provide a user-friendly format first adapted to our current usage, and make it improve as we go along. Complexity is not our friend at our stage from my POV 🤓 

Let me know if you want me to add something else 😇 