### PR TITLE
API Guideline - Return list of API resources under a `results` array

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -29,6 +29,14 @@ components:
       type: integer
       description: Limit given for the query. If limit is not provided as a query parameter, this parameter displays the default limit value.
       example: 10
+    offset:
+      type: integer
+      description: Offset given for the query. If offset is not provided as a query parameter, this parameter displays the default offset value.
+      example: 0
+    total:
+      type: integer
+      description: Total number of browsable results using offset/limit parameters for the given resource.
+      example: 50
     from:
       type: integer
       description: The first task uid returned.
@@ -675,14 +683,14 @@ components:
     limit:
       name: limit
       in: query
-      description: Maximum number of documents to return.
+      description: Maximum number of results to return.
       schema:
         type: number
         default: 20
     offset:
       name: offset
       in: query
-      description: Number of documents to skip.
+      description: Number of results to skip.
       schema:
         type: number
         default: 0
@@ -1020,6 +1028,17 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/index'
+                  limit:
+                    $ref: '#/components/schemas/limit'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  total:
+                    $ref: '#/components/schemas/total'
+                required:
+                  - results
+                  - limit
+                  - offset
+                  - total
               examples:
                 Example:
                   value:
@@ -1029,8 +1048,14 @@ paths:
                         primaryKey: movie_id
                         createdAt: '2019-11-20T09:40:33.711324Z'
                         updatedAt: '2019-11-20T09:40:33.711324Z'
+                    limit: 1
+                    offset: 0
+                    total: 1
         '401':
           $ref: '#/components/responses/401'
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
       operationId: indexes.create
       summary: Create Index
@@ -1202,6 +1227,17 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/document'
+                  limit:
+                    $ref: '#/components/schemas/limit'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  total:
+                    $ref: '#/components/schemas/total'
+                required:
+                  - results
+                  - limit
+                  - offset
+                  - total
               examples:
                 Example:
                   value:
@@ -1216,7 +1252,9 @@ paths:
                         poster: 'https://image.tmdb.org/t/p/w500/4X7quIcdkc24Cveg5XdpfRqxtYA.jpg'
                         overview: "The Bridge of San Luis Rey is American author Thornton Wilder's second novel, first published in 1927 to worldwide acclaim. It tells the story of several interrelated people who die in the collapse of an Inca rope-fiber suspension bridge in Peru, and the events that lead up to their being on the bridge.[ A friar who has witnessed the tragic accident then goes about inquiring into the lives of the victims, seeking some sort of cosmic answer to the question of why each had to die. The novel won the Pulitzer Prize in 1928."
                         release_date: 1072915200
-
+                    limit: 20
+                    offset: 0
+                    total: 2
         '401':
           $ref: '#/components/responses/401'
         '404':
@@ -2516,6 +2554,17 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/key'
+                  limit:
+                    $ref: '#/components/schemas/limit'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  total:
+                    $ref: '#/components/schemas/total'
+                required:
+                  - results
+                  - limit
+                  - offset
+                  - total
               examples:
                 example-1:
                   value:
@@ -2529,8 +2578,14 @@ paths:
                         expiresAt: '2022-11-12T10:00:00Z'
                         createdAt: '2021-11-12T10:00:00Z'
                         updatedAt: '2021-11-12T10:00:00Z'
+                    limit: 20
+                    offset: 0
+                    total: 1
         '401':
           $ref: '#/components/responses/401'
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
   '/keys/{key}':
     get:
       summary: Get an API key

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -84,7 +84,7 @@ components:
         title: American Ninja 5
         poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
         overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-        release_date: '1993-01-01'
+        release_date: 725846400
       description: 'A document made of attribute. The maximum number of attribute for a document is 65,535.'
     matchesPosition:
       type: object
@@ -106,13 +106,13 @@ components:
         title: American Ninja 5
         poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
         overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-        release_date: '1993-01-01'
+        release_date: 725846400
         _formatted:
           id: 25684
           title: American Ninja 5
           poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
           overview: 'When a scientists daughter is kidnapped, American <em>Ninja</em>, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the <em>ninja</em>.'
-          release_date: '1993-01-01'
+          release_date: 725846400
         _matchesPosition:
           overview:
             - start: 49
@@ -124,13 +124,13 @@ components:
           title: American Ninja 5
           poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
           overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-          release_date: '1993-01-01'
+          release_date: 725846400
           _formatted:
             id: 25684
             title: American Ninja 5
             poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
             overview: 'When a scientists daughter is kidnapped, American <em>Ninja</em>, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the <em>ninja</em>.'
-            release_date: '1993-01-01'
+            release_date: 725846400
           _matchesPosition:
             overview:
               - start: 49
@@ -1014,17 +1014,21 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/index'
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/index'
               examples:
                 Example:
                   value:
-                    - uid: movies
-                      name: movies
-                      primaryKey: movie_id
-                      createdAt: '2019-11-20T09:40:33.711324Z'
-                      updatedAt: '2019-11-20T09:40:33.711324Z'
+                    results:
+                      - uid: movies
+                        name: movies
+                        primaryKey: movie_id
+                        createdAt: '2019-11-20T09:40:33.711324Z'
+                        updatedAt: '2019-11-20T09:40:33.711324Z'
         '401':
           $ref: '#/components/responses/401'
     post:
@@ -1192,17 +1196,27 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/document'
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/document'
               examples:
                 Example:
                   value:
-                    - id: 25684
-                      title: American Ninja 5
-                      poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
-                      overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-                      release_date: '1993-01-01'
+                    results:
+                      - id: 25684
+                        title: American Ninja 5
+                        poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
+                        overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
+                        release_date: 725846400
+                      - id: 45881
+                        title: The Bridge of San Luis Rey
+                        poster: 'https://image.tmdb.org/t/p/w500/4X7quIcdkc24Cveg5XdpfRqxtYA.jpg'
+                        overview: "The Bridge of San Luis Rey is American author Thornton Wilder's second novel, first published in 1927 to worldwide acclaim. It tells the story of several interrelated people who die in the collapse of an Inca rope-fiber suspension bridge in Peru, and the events that lead up to their being on the bridge.[ A friar who has witnessed the tragic accident then goes about inquiring into the lives of the victims, seeking some sort of cosmic answer to the question of why each had to die. The novel won the Pulitzer Prize in 1928."
+                        release_date: 1072915200
+
         '401':
           $ref: '#/components/responses/401'
         '404':
@@ -1290,7 +1304,7 @@ paths:
                     title: American Ninja 5
                     poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
                     overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-                    release_date: '1993-01-01'
+                    release_date: 725846400
         description: ''
       responses:
         '202':
@@ -1446,13 +1460,13 @@ paths:
                         title: American Ninja 5
                         poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
                         overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-                        release_date: '1993-01-01'
+                        release_date: 725846400
                         _formatted:
                           id: 25684
                           title: American Ninja 5
                           poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
                           overview: 'When a scientists daughter is kidnapped, American <em>Ninja</em>, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the <em>ninja</em>.'
-                          release_date: '1993-01-01'
+                          release_date: 725846400
                         _matchesPosition:
                           overview:
                             - start: 49
@@ -1588,13 +1602,13 @@ paths:
                         title: American Ninja 5
                         poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
                         overview: 'When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.'
-                        release_date: '1993-01-01'
+                        release_date: 725846400
                         _formatted:
                           id: 25684
                           title: American Ninja 5
                           poster: 'https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg'
                           overview: 'When a scientists daughter is kidnapped, American <em>Ninja</em>, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the <em>ninja</em>.'
-                          release_date: '1993-01-01'
+                          release_date: 725846400
                         _matchesPosition:
                           overview:
                             - start: 49

--- a/text/0085-api-keys.md
+++ b/text/0085-api-keys.md
@@ -367,8 +367,67 @@ Only the master key allows managing the API keys.
 ```
 "Authorization: Bearer :masterKey"
 ```
+##### Query Parameters
 
-##### Response
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `offset`                 | Integer / `null`         | false    |
+| `limit`                  | Integer / `null`         | false    |
+
+###### `offset`
+
+- Type: Integer
+- Required: False
+- Default: `0`
+
+Sets the starting point in the results, effectively skipping over a given number of API keys.
+
+###### `limit`
+
+- Type: Integer
+- Required: False
+- Default: `20`
+
+Sets the maximum number of documents to be returned by the current request.
+
+##### Response Definition
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `result`                 | Array[Key]               | true     |
+| `offset`                 | Integer                  | true     |
+| `limit`                  | Integer                  | true     |
+| `total`                  | Integer                  | true     |
+
+###### `results`
+
+- Type: Array[Key]
+- Required: True
+
+An array containing the fetched API keys.
+
+###### `offset`
+
+- Type: Integer
+- Required: True
+
+Gives the `offset` parameter used for the query.
+
+###### `limit`
+
+- Type: Integer
+- Required: True
+
+Gives the `limit` parameter used for the query.
+
+###### `total`
+
+- Type: Integer
+- Required: True
+
+Gives the total number of API keys that can be browsed.
+
+###### Example
 
 `200 Success`
 
@@ -416,7 +475,10 @@ Only the master key allows managing the API keys.
             "createdAt": "2021-08-11T10:00:00Z",
             "updatedAt": "2021-08-11T10:00:00Z"
         }
-    ]
+    ],
+    "offset": 0,
+    "limit": 20,
+    "total": 3
 }
 ```
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -53,7 +53,7 @@ Unique identifier of an index.
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `offset`                 | Integer / `null`         | false    |
-| `limit`                  | String / `null`          | false    |
+| `limit`                  | Integer / `null`         | false    |
 | `attributesToRetrieve`   | String / `null`          | false    |
 
 ###### 3.1.1.2.1. `offset`
@@ -95,6 +95,7 @@ A `results` array representing documents as JSON objects.
 | `results`                | Array[Document]          | true     |
 | `offset`                 | Integer                  | true     |
 | `limit`                  | Integer                  | true     |
+| `total`                  | Integer                  | true     |
 
 ###### 3.1.1.3.1. `results`
 
@@ -121,6 +122,12 @@ Gives the `limit` parameter used for the query.
 
 > See [3.1.1.2.2. `limit`](#31122-limit) section.
 
+###### 3.1.1.3.3. `total`
+
+- Type: Integer
+- Required: True
+
+Gives the total number of documents that can be browsed in the related index.
 
 ###### 3.1.1.3.4. Example
 
@@ -137,7 +144,8 @@ Gives the `limit` parameter used for the query.
     }
   ],
   "offset": 0,
-  "limit": 2
+  "limit": 2,
+  "total": 3 //The index contains 3 documents in total
 }
 ```
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -129,17 +129,11 @@ Gives the `limit` parameter used for the query.
   "results": [
     {
       "id": 25684,
-      "release_date": "1993-01-01",
-      "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-      "title": "American Ninja 5",
-      "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
+      "title": "American Ninja 5"
     },
     {
       "id": 468219,
-      "title": "Dead in a Week (Or Your Money Back)",
-      "release_date": "2018-09-12",
-      "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-      "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
+      "title": "Dead in a Week (Or Your Money Back)"
     }
   ],
   "offset": 0,

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -88,27 +88,63 @@ If no value is specified, `attributesToRetrieve` uses the `displayedAttributes` 
 
 ##### 3.1.1.3. Response Definition
 
-An array of documents represented as JSON objects.
+A `results` array representing documents as JSON objects.
 
-###### 3.1.1.3.1. Example
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `results`                | Array[Document]          | true     |
+| `offset`                 | Integer                  | true     |
+| `limit`                  | Integer                  | true     |
+
+###### 3.1.1.3.1. `results`
+
+- Type: Array[Document]
+- Required: True
+
+Contains the fetched documents.
+
+###### 3.1.1.3.2. `offset`
+
+- Type: Integer
+- Required: True
+
+Gives the `offset` parameter used for the query.
+
+> See [3.1.1.2.1. `offset`](#31121-offset) section.
+
+###### 3.1.1.3.3. `limit`
+
+- Type: Integer
+- Required: True
+
+Gives the `limit` parameter used for the query.
+
+> See [3.1.1.2.2. `limit`](#31122-limit) section.
+
+
+###### 3.1.1.3.4. Example
 
 ```json
-[
-  {
-    "id": 25684,
-    "release_date": "1993-01-01",
-    "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-    "title": "American Ninja 5",
-    "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
-  },
-  {
-    "id": 468219,
-    "title": "Dead in a Week (Or Your Money Back)",
-    "release_date": "2018-09-12",
-    "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-    "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
-  }
-]
+{
+  "results": [
+    {
+      "id": 25684,
+      "release_date": "1993-01-01",
+      "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+      "title": "American Ninja 5",
+      "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
+    },
+    {
+      "id": 468219,
+      "title": "Dead in a Week (Or Your Money Back)",
+      "release_date": "2018-09-12",
+      "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
+      "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
+    }
+  ],
+  "offset": 0,
+  "limit": 2
+}
 ```
 
 ##### 3.1.1.4. Errors

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -101,7 +101,7 @@ A `results` array representing documents as JSON objects.
 - Type: Array[Document]
 - Required: True
 
-Contains the fetched documents.
+An array containing the fetched documents.
 
 ###### 3.1.1.3.2. `offset`
 

--- a/text/0132-indexes-api.md
+++ b/text/0132-indexes-api.md
@@ -109,7 +109,7 @@ A `results`  array containing indexes of the Meilisearch instance.
 - Type: Array[Index]
 - Required: True
 
-Contains the fetched indexes.
+An array containing the fetched indexes.
 
 #### 3.2.2. `GET` - `indexes/:index_uid`
 

--- a/text/0132-indexes-api.md
+++ b/text/0132-indexes-api.md
@@ -228,3 +228,4 @@ N/A
 ## 5. Future Possibilities
 - Delete `uid` or `name`.
 - Rework the `primaryKey` concept
+- Paginate `GET` - `/indexes`

--- a/text/0132-indexes-api.md
+++ b/text/0132-indexes-api.md
@@ -98,7 +98,7 @@ List all indexes of a Meilisearch instance.
 
 ##### 3.2.1.1. Response Definition
 
-A `results`  array containing indexes of the Meilisearch instance.
+An object containing all the indexes.
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|

--- a/text/0132-indexes-api.md
+++ b/text/0132-indexes-api.md
@@ -13,8 +13,6 @@ Indexes contain a set of documents in which to search and have their specific se
 
 See [Documents API specification](0124-documents-api.md) and [Settings API specification](0123-settings-api.md) for more details.
 
-### 3.1. API Endpoints Definition
-
 
 ### 3.1. `index` API Resource Definition
 
@@ -100,7 +98,18 @@ List all indexes of a Meilisearch instance.
 
 ##### 3.2.1.1. Response Definition
 
-Returns an array made of multiple index API resource objects. See [3.1.2.1. Response Definition](#3121-response-definition) section.
+A `results`  array containing indexes of the Meilisearch instance.
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `results`                | Array[Index]             | true     |
+
+###### 3.2.1.1.1. `results`
+
+- Type: Array[Index]
+- Required: True
+
+Contains the fetched indexes.
 
 #### 3.2.2. `GET` - `indexes/:index_uid`
 

--- a/text/0132-indexes-api.md
+++ b/text/0132-indexes-api.md
@@ -96,20 +96,73 @@ Manipulate indexes of a Meilisearch instance.
 
 List all indexes of a Meilisearch instance.
 
-##### 3.2.1.1. Response Definition
+The results are sorted in ascending alphanumeric order from the `uid` field.
+
+##### 3.2.1.1. Query Parameters
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `offset`                 | integer / `null`         | false    |
+| `limit`                  | integer / `null`         | false    |
+
+###### 3.2.1.1.1. `offset`
+
+- Type: Integer
+- Required: False
+- Default: `0`
+
+Sets the starting point in the results, effectively skipping over a given number of indexes.
+
+###### 3.2.1.1.2. `limit`
+
+- Type: Integer
+- Required: False
+- Default: `20`
+
+Sets the maximum number of indexes to be returned by the current request.
+
+##### 3.2.1.2. Response Definition
 
 An object containing all the indexes.
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `results`                | Array[Index]             | true     |
+| `offset`                 | integer                  | true     |
+| `limit`                  | integer                  | true     |
+| `total`                  | integer                  | true     |
 
-###### 3.2.1.1.1. `results`
+###### 3.2.1.2.1. `results`
 
 - Type: Array[Index]
 - Required: True
 
 An array containing the fetched indexes.
+
+###### 3.2.1.2.2. `offset`
+
+- Type: Integer
+- Required: True
+
+Gives the `offset` parameter used for the query.
+
+> See [3.2.1.1.1. `offset`](#32111-offset) section.
+
+###### 3.2.1.2.3. `limit`
+
+- Type: Integer
+- Required: True
+
+Gives the `limit` parameter used for the query.
+
+> See [3.2.1.1.2. `limit`](#32112-limit) section.
+
+###### 3.2.1.2.3. `total`
+
+- Type: Integer
+- Required: True
+
+Gives the total number of indexes that can be browsed.
 
 #### 3.2.2. `GET` - `indexes/:index_uid`
 


### PR DESCRIPTION
🤖 [API Diff](https://github.com/meilisearch/specifications/pull/138#issuecomment-1090115742)

## Why?

In order to stabilize the APIs around a convention, we add resources under a `results` array when they can be listed. 

This is already the case for the `tasks` and `API Keys` resources which have made this change along the way.

The `/search` endpoints are not affected by these changes but this can be reconsidered with caution. `hits` seem to be effective and changing it would cause a big breaking change. `hits` is already well established in the market e.g. elasticsearch, algolia, typesense.

The stats API is not concerned for the moment and maybe concerned later given feedback and what it could become. The idea behind it is that this resource does not only return index statistics but also more global statistics which makes the use of `results` less straightforward.

## TODO

- [x] Indexes API
- [x] Documents API
- [x] limit/offset pagination for Indexes API
- [x] limit/offset pagination for Keys API
- [x] Update OpenAPI

## Changes

- Returns `index` API resources on `GET - /indexes` under a `results` array + offset/limit pagination.
    - Add `limit` (Default: `20`) and `offset`(Default: `0`) query parameters.
    - Add `limit`, `offset` and `total` in the response body.
- Returns `document` API resources on `/documents` under a `results` array.
    - Add `limit`, `offset` and `total` in the response body.
- Add an offset/limit pagination on `GET - /keys`
    - Add `limit` (Default: `20`) and `offset`(Default: `0`) query parameters.
    - Add `limit`, `offset` and `total` in the response body.