### PR TITLE
Documents API - `displayedAttributes` should not impact the documents API / Rename `attributesToRetrieve` to `fields`

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -156,7 +156,7 @@ components:
           type:
             - string
             - number
-          description: Retrieve attributes of the document. `attributesToRetrieve` controls these fields.
+          description: Retrieve attributes of a search result. `attributesToRetrieve` controls these fields.
         _geoDistance:
           type: number
           description: 'Using _geoPoint({lat}, {lng}) built-in sort rule at search leads the engine to return a _geoDistance within the search results. This field represents the distance in meters of the document from the specified _geoPoint.'
@@ -815,6 +815,16 @@ components:
 
         > warn
         > Attribute(s) used in `filter` should be declared as filterable attributes. See [Filtering and Faceted Search](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html).
+    fields:
+      name: fields
+      in: query
+      description: 'Comma-separated list of fields to display for an API resource. By default it contains all fields of an API resource.'
+      schema:
+        type: string
+        items:
+          type: string
+        example: 'uid,createdAt'
+        default: '*'
     Content-Type:
       name: Content-Type
       in: header
@@ -1255,7 +1265,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/attributesToRetrieve'
+        - $ref: '#/components/parameters/fields'
     post:
       operationId: indexes.documents.create
       summary: Add or replace documents
@@ -1431,6 +1441,8 @@ paths:
           $ref: '#/components/responses/401'
         '404':
           description: Not Found
+      parameters:
+        - $ref: '#/components/parameters/fields'
     delete:
       operationId: indexes.documents.remove
       summary: Delete one document

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -78,11 +78,16 @@ Sets the maximum number of documents to be returned by the current request.
 
 - Type: String
 - Required: False
-- Default: `null`
+- Default: `*`
 
 Configures which attributes will be retrieved in the returned documents.
 
-If no value is specified, all attributes from the documents are returned in the response.
+If `fields` is not specified, all attributes from the documents are returned in the response. It's equivalent to `fields=*`.
+
+- Sending `fields` without specifying a value, returns empty documents ressources. `fields=`.
+- Sending `fields` with a non-existent field as part of the value will not return an error, the non-existent field will not be displayed.
+
+> `fields` values are case-sensitive.
 
 > Specified fields have to be separated by a comma. e.g. `&fields=title,description`
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -55,8 +55,8 @@ Unique identifier of an index.
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `offset`                 | Integer / `null`         | false    |
-| `limit`                  | Integer / `null`         | false    |
-| `attributesToRetrieve`   | String / `null`          | false    |
+| `limit`                  | String / `null`          | false    |
+| `fields`                 | String / `null`          | false    |
 
 ###### 3.1.1.2.1. `offset`
 
@@ -74,7 +74,7 @@ Sets the starting point in the results, effectively skipping over a given number
 
 Sets the maximum number of documents to be returned by the current request.
 
-###### 3.1.1.2.3. `attributesToRetrieve`
+###### 3.1.1.2.3. `fields`
 
 - Type: String
 - Required: False
@@ -84,7 +84,7 @@ Configures which attributes will be retrieved in the returned documents.
 
 If no value is specified, all attributes from the documents are returned in the response.
 
-> Specified fields have to be separated by a comma. e.g. `&attributesToRetrieve=title,description`
+> Specified fields have to be separated by a comma. e.g. `&fields=title,description`
 
 > The index setting `displayedAttributes` has no impact on this endpoint.
 
@@ -155,7 +155,7 @@ Gives the total number of documents that can be browsed in the related index.
 
 - 🔴 Sending a value with a different type than `Integer` or `null` for `offset` will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 - 🔴 Sending a value with a different type than `Integer` or `null` for `limit` will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
-- 🔴 Sending a value with a different type than `String` or `null` for `attributesToRetrieve` will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
+- 🔴 Sending a value with a different type than `String` or `null` for `fields` will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
 #### 3.1.2. `GET` - `indexes/:index_uid/documents/:document_id`
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -4,6 +4,8 @@
 
 This specification describes the documents API endpoints permitting to list, fetch, add/replace, and delete index documents.
 
+It is an API dedicated to document management within the Meilisearch index.
+
 ## 2. Motivation
 N/A
 
@@ -80,11 +82,11 @@ Sets the maximum number of documents to be returned by the current request.
 
 Configures which attributes will be retrieved in the returned documents.
 
-If no value is specified, `attributesToRetrieve` uses the `displayedAttributes` list, which by default contains all attributes found in the documents.
-
-> If an attribute has been removed from `displayedAttributes` index settings, `attributesToRetrieve` will silently ignore it and the field will not appear in the returned documents.
+If no value is specified, all attributes from the documents are returned in the response.
 
 > Specified fields have to be separated by a comma. e.g. `&attributesToRetrieve=title,description`
+
+> The index setting `displayedAttributes` has no impact on this endpoint.
 
 ##### 3.1.1.3. Response Definition
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -491,4 +491,5 @@ The auth layer can return the following errors if Meilisearch is secured (a mast
 N/A
 
 ## 5. Future Possibilities
-N/A
+
+- Introduce a way to reject fields from a document in the response. e.g. `?fields=-createdAt`

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -187,14 +187,39 @@ Unique identifier of an index.
 
 Unique identifier of a document.
 
-##### 3.1.2.1. Request Payload Definition
+##### 3.1.2.2. Query Parameters
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `fields`                 | String / `null`          | false    |
+
+###### 3.1.2.2.1. `fields`
+
+- Type: String
+- Required: False
+- Default: `*`
+
+Configures which attributes will be retrieved in the returned documents.
+
+If `fields` is not specified, all attributes from the documents are returned in the response. It's equivalent to `fields=*`.
+
+- Sending `fields` without specifying a value, returns empty documents ressources. `fields=`.
+- Sending `fields` with a non-existent field as part of the value will not return an error, the non-existent field will not be displayed.
+
+> `fields` values are case-sensitive.
+
+> Specified fields have to be separated by a comma. e.g. `&fields=title,description`
+
+> The index setting `displayedAttributes` has no impact on this endpoint.
+
+##### 3.1.2.3. Request Payload Definition
 N/A
 
-##### 3.1.2.2. Response Definition
+##### 3.1.2.4. Response Definition
 
 A document represented as a JSON object.
 
-##### 3.1.2.2.1. Example
+##### 3.1.2.4.1. Example
 
 ```json
 {
@@ -206,10 +231,11 @@ A document represented as a JSON object.
 }
 ```
 
-##### 3.1.2.3. Errors
+##### 3.1.2.5. Errors
 
 - 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
 - 🔴 If the requested `document_id` does not exist, the API returns an [document_not_found](0061-error-format-and-definitions.md#document_not_found) error.
+- 🔴 Sending a value with a different type than `String` or `null` for `fields` will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
 #### 3.1.3. `POST` - `indexes/:index_uid/documents`
 


### PR DESCRIPTION
🤖 [API Diff](url)

## Why?

The documents API is used to manage documents within an index.

`displayedAttributes` allows limiting the attributes that can be retrieved in the search but also impacts the endpoints of the documents API.

My proposal is to remove this behavior from the documents API. Indeed, in order to manage a Meilisearch instance, it is good to have all the information about it.

Today, it implies the user to modify `displayedAttributes` to access all the information which will also impact the search. This is not desirable for the developer experience.

---

Following this [discussion ](https://github.com/meilisearch/product/discussions/440)

`attributesToRetrieve` query parameter is renamed to `fields` on this API. Using a more generic name that does not collide with `attributesToRetrieve` from the `search` endpoint could help consistency if we add this feature on another API endpoints in the future.

Rejecting a field from a document in the given response with a negative operator is added as a future possibility. e.g. `?fields=-createdAt`

## Changes

- `displayedAttributes` do not impact the documents API.
- Rename `attributesToRetrieve` on the document API to `fields`. It's more generic and thus can be used on all routes other than search in the future as a query parameter component.