### PR TITLE
Tasks API - Rename `uid` to `taskUid` in the `202 - Accepted` Summarized Task Response

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -828,9 +828,9 @@ components:
           schema:
             type: object
             properties:
-              uid:
+              taskUid:
                 type: number
-                description: 'This `uid` allows you to [track the current task](https://docs.meilisearch.com/reference/api/tasks.html).'
+                description: 'This `taskUid` allows you to [track the current task](https://docs.meilisearch.com/reference/api/tasks.html).'
               indexUid:
                 type: string
                 description: The unique identifier of the index where this task is operated
@@ -850,7 +850,7 @@ components:
           examples:
             Example:
               value:
-                uid: 0
+                taskUid: 0
                 indexUid: movies
                 status: enqueued
                 enqueuedAt: '2021-07-19T14:31:16.920473Z'

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -75,7 +75,7 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 | field      | type    | description                     |
 |------------|---------|---------------------------------|
-| taskUid    | integer | Unique sequential identifier           |
+| taskUid    | integer | Unique sequential identifier |
 | indexUid   | string | Unique index identifier |
 | status     | string  | Status of the task. Value is `enqueued` |
 | enqueuedAt | string | Represent the date and time as `RFC 3339` format when the task has been enqueued |

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -75,7 +75,7 @@ The motivation is to stabilize the current `update` resource to a version that c
 
 | field      | type    | description                     |
 |------------|---------|---------------------------------|
-| uid        | integer | Unique sequential identifier           |
+| taskUid    | integer | Unique sequential identifier           |
 | indexUid   | string | Unique index identifier |
 | status     | string  | Status of the task. Value is `enqueued` |
 | enqueuedAt | string | Represent the date and time as `RFC 3339` format when the task has been enqueued |
@@ -293,7 +293,7 @@ e.g. A summarized `task` object in a `202 Accepted` HTTP response returned at in
 
 ```json
 {
-    "uid": 0,
+    "taskUid": 0,
     "indexUid": "movies",
     "status": "enqueued",
     "type": "createIndex",
@@ -524,7 +524,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 ```json
 {
-    "uid": 0,
+    "taskUid": 0,
     "indexUid": "movies",
     "status": "enqueued",
     "type": "indexCreation",
@@ -546,7 +546,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 ```json
 {
-    "uid": 1,
+    "taskUid": 1,
     "indexUid": "movies",
     "status": "enqueued",
     "type": "indexUpdate",
@@ -560,7 +560,7 @@ New task types are also added for these operations. `indexCreation`, `indexUpdat
 
 ```json
 {
-    "uid": 1,
+    "taskUid": 1,
     "indexUid": "movies",
     "status": "enqueued",
     "type": "indexDeletion",


### PR DESCRIPTION
🤖 [API Diff](https://github.com/meilisearch/specifications/pull/144#issuecomment-1104996509)

## Why?

Following this [discussion](https://github.com/meilisearch/product/issues/368#issuecomment-1104900879), we decided to rename the `uid` field in a summarized task response (202 Accepted) to `taskUid` to bring more context and help understanding what is given as a response.

## Changes

- `uid` contained in 202 Accepted (Summarized Task Response) is renamed to `taskUid`