### PR TITLE
Telemetry - Add `x-meilisearch-client` query parameter

### DIFF
--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -417,6 +417,12 @@ The `User-Agent` header is tracked on the events listed below. Our official SDKs
 
 Each endpoint API tracked sends the `User-Agent` as a `user_agent` event property as an array. If several values are contained in the `User-Agent` header, they are split by the `;` character.
 
+##### `x-meilisearch-client` Query Parameter
+
+Some browser engines prevent overloading the User-Agent header. In order to track the calls made by some clients concerned by this fact, e.g. the javascript SDK, it is possible to use the `x-meilisearch-client` query parameter.
+
+If the query parameter is encountered, it overrides the presence of the User-Agent header.
+
 #### Identifying MeiliSearch installation
 
 To identify instances, we generate a unique identifier at first launch if analytics are not disabled.

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -421,7 +421,7 @@ Each endpoint API tracked sends the `User-Agent` as a `user_agent` event propert
 
 Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `x-meilisearch-client` query parameter.
 
-If the query parameter is encountered, it overrides the presence of the User-Agent header.
+If the query parameter is encountered, it overrides the presence of the `User-Agent` header.
 
 #### Identifying MeiliSearch installation
 

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -419,7 +419,7 @@ Each endpoint API tracked sends the `User-Agent` as a `user_agent` event propert
 
 ##### `x-meilisearch-client` Query Parameter
 
-Some browser engines prevent overloading the User-Agent header. In order to track the calls made by some clients concerned by this fact, e.g. the javascript SDK, it is possible to use the `x-meilisearch-client` query parameter.
+Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `x-meilisearch-client` query parameter.
 
 If the query parameter is encountered, it overrides the presence of the User-Agent header.
 


### PR DESCRIPTION
## Why?

Following this [comment](https://github.com/meilisearch/integration-guides/issues/150#issuecomment-966360488) pointing out that some browsers forbid the customization of the User-Agent header, the analytics stack can now take the value of a `x-meilisearch-client` query parameter if found instead of the user-agent header to track the usage of our SDKs/Integrations.