### PR TITLE
Geosearch - Enhance lat/lng format error messages

### DIFF
--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -119,40 +119,6 @@ csv format example
 
 - 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. A new `invalid_geo_field` error is given in the `update` object.
 
-##### Errors Definition
-
-## invalid_geo_field
-
-### Context
-
-These errors occurs when the `_geo` field of a document payload is not valid. Either the latitude / longitude is missing or is not a number.
-
-### Error Definition
-
-- When one field is missing the following error is thrown:
-```json
-{
-    "message": "Could not find :coord in the document with the id: `:documentId`. Was expecting a `:field` field.",
-    "code": "invalid_geo_field",
-    "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
-}
-```
-
-- When the coordinate can't be parsed:
-```json
-{
-    "message": "Could not parse :coord in the document with the id: `:documentId`. Was expecting a number but instead got `:value`.",
-    "code": "invalid_geo_field",
-    "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
-}
-```
-
-- The `:documentId` is inferred when the message is generated.
-- The `:coord` is either `latitude` or `longitude` depending on what's wrong.
-- The `:field` is either `_geo.lat` or `_geo.lng` depending on what's wrong.
-
 ---
 
 ### **As an end-user, I want to filter documents within a geo radius.**

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -125,13 +125,24 @@ csv format example
 
 ### Context
 
-This error occurs when the `_geo` field of a document payload is not valid.
+These errors occurs when the `_geo` field of a document payload is not valid. Either the latitude / longitude is missing or is not a number.
 
 ### Error Definition
 
+- When one field is missing the following error is thrown:
 ```json
 {
-    "message": "The document with the id: `:documentId` contains an invalid _geo field: :syntaxErrorHelper.",
+    "message": "Could not find :coord in the document with the id: `:documentId`. Was expecting a `:field` field.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+- When the coordinate can't be parsed:
+```json
+{
+    "message": "Could not parse :coord in the document with the id: `:documentId`. Was expecting a number but instead got `:value`.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
@@ -139,7 +150,8 @@ This error occurs when the `_geo` field of a document payload is not valid.
 ```
 
 - The `:documentId` is inferred when the message is generated.
-- The `:syntaxErrorHelper` is inferred when the message is generated.
+- The `:coord` is either `latitude` or `longitude` depending on what's wrong.
+- The `:field` is either `_geo.lat` or `_geo.lng` depending on what's wrong.
 
 ---
 

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -628,22 +628,35 @@ HTTP Code: `400 Bad Request`
 
 ### Context
 
-This error occurs when the `_geo` field of a document payload is not valid.
+These errors occurs when the `_geo` field of a document payload is not valid. Either the latitude / longitude is missing or is not a number.
 
 ### Error Definition
 
+#### Variant: Missing `_geo.lat` or `_geo.lng` field.
+
 ```json
 {
-    "message": "The document with the id: `:documentId` contains an invalid _geo field: `:syntaxErrorHelper`.",
+    "message": "Could not find :coord in the document with the id: `:documentId`. Was expecting a `:field` field.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
 }
-
 ```
 
-- The `:documentId` is inferred when the error message is generated.
-- The `:syntaxErrorHelper` is inferred when the error message is generated.
+#### Variant: Coordinate can't be parsed.
+
+```json
+{
+    "message": "Could not parse :coord in the document with the id: `:documentId`. Was expecting a number but instead got `:value`.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+- The `:documentId` is inferred when the message is generated.
+- The `:coord` is either `latitude` or `longitude` depending on what's wrong.
+- The `:field` is either `_geo.lat` or `_geo.lng` depending on what's wrong.
 
 ---
 


### PR DESCRIPTION
It’s also important to note that the first error message could not stay the same (and show the whole object) as before because we lost this information with the v0.27 and the nested fields 😢 