### PR TITLE
Telemetry - Replace `x-meilisearch-client` query parameter by `X-Meilisearch-Client` header

### DIFF
--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -416,11 +416,11 @@ The `User-Agent` header is tracked on the events listed below. Our official SDKs
 
 Each endpoint API tracked sends the `User-Agent` as a `user_agent` event property as an array. If several values are contained in the `User-Agent` header, they are split by the `;` character.
 
-##### `x-meilisearch-client` Query Parameter
+##### `X-MEILISEARCH-CLIENT` Header
 
-Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `x-meilisearch-client` query parameter.
+Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `X-MEILISEARCH-CLIENT` custom header.
 
-If the query parameter is encountered, it overrides the presence of the `User-Agent` header.
+If the `X-MEILISEARCH-CLIENT` is encountered, it overrides the presence of the `User-Agent` header.
 
 #### Identifying MeiliSearch installation
 

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -416,11 +416,11 @@ The `User-Agent` header is tracked on the events listed below. Our official SDKs
 
 Each endpoint API tracked sends the `User-Agent` as a `user_agent` event property as an array. If several values are contained in the `User-Agent` header, they are split by the `;` character.
 
-##### `X-MEILISEARCH-CLIENT` Header
+##### `X-Meilisearch-Client` Header
 
-Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `X-MEILISEARCH-CLIENT` custom header.
+Some browser engines prevent overloading the User-Agent header. To track the calls made by some clients concerned by this fact, e.g. the JavaScript SDK, it is possible to use the `X-Meilisearch-Client` custom header.
 
-If the `X-MEILISEARCH-CLIENT` is encountered, it overrides the presence of the `User-Agent` header.
+If the `X-Meilisearch-Client` is encountered, it overrides the presence of the `User-Agent` header.
 
 #### Identifying MeiliSearch installation
 


### PR DESCRIPTION
## Why?

Following #145, the core team had some technical difficulties implementing it.

We decided to replace the `x-meilisearch-client` query parameter with a custom header.

According to our exploration, a custom header is rarely stripped by a proxy by default (_tested on nginx_). If it still happens, the analytics will just not be collected in this case.

We found this solution to be the least impactful regarding the user experience while ensuring that it can be implemented quickly without rewriting how the API passes an `x-meilisearch-client` query parameter for a non-business field to the end-user POV.