### PR TITLE
Search API — Add `matchingStrategy` parameter with `last` / `all` strategies

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -847,6 +847,17 @@ components:
         type: boolean
         default: 'false'
       description: Defines whether an `_matchesPosition` object that contains information about the matches should be returned or not.
+    wordMatchingStrategy:
+      name: wordMatchingStrategy
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - last
+          - all
+        default: 'last'
+      description: Defines which strategy to use to match the query terms within the documents as search results. Two different strategies are available, `last` and `all`. By default, the `last` strategy is chosen.
     sort:
       name: sort
       in: query
@@ -1620,6 +1631,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/showMatchesPosition'
+        - $ref: '#/components/parameters/wordMatchingStrategy'
       responses:
         '200':
           description: Ok
@@ -1724,6 +1736,10 @@ paths:
                   type: boolean
                   description: Defines whether an `_matchesPosition` object that contains information about the matches should be returned or not.
                   default: false
+                wordMatchingStrategy:
+                  type: string
+                  description: Defines which strategy to use to match the query terms within the documents as search results. Two different strategies are available, `last` and `all`. By default, the `last` strategy is chosen.
+                  default: 'last'
                 filter:
                   $ref: '#/components/schemas/filter'
                 facets:
@@ -1762,6 +1778,7 @@ paths:
                   attributesToHighlight:
                     - overview
                   showMatchesPosition: true
+                  wordsMatchingStrategy: all
       responses:
         '200':
           description: Ok

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -847,8 +847,8 @@ components:
         type: boolean
         default: 'false'
       description: Defines whether an `_matchesPosition` object that contains information about the matches should be returned or not.
-    wordMatchingStrategy:
-      name: wordMatchingStrategy
+    matchingStrategy:
+      name: matchingStrategy
       in: query
       required: false
       schema:
@@ -1631,7 +1631,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/showMatchesPosition'
-        - $ref: '#/components/parameters/wordMatchingStrategy'
+        - $ref: '#/components/parameters/matchingStrategy'
       responses:
         '200':
           description: Ok
@@ -1736,7 +1736,7 @@ paths:
                   type: boolean
                   description: Defines whether an `_matchesPosition` object that contains information about the matches should be returned or not.
                   default: false
-                wordMatchingStrategy:
+                matchingStrategy:
                   type: string
                   description: Defines which strategy to use to match the query terms within the documents as search results. Two different strategies are available, `last` and `all`. By default, the `last` strategy is chosen.
                   default: 'last'

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -135,7 +135,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filtered_by_type`                      | `true` if `GET /tasks` endpoint is filered by `type`, otherwise `false` | false | `Tasks Seen` |
 | `filtered_by_status`                    | `true` if `GET /tasks` endpoint is filered by `status`, otherwise `false` | false | `Tasks Seen` |
 | `per_index_uid` | `true` if an uid is used to fetch an index stat resource, otherwise `false` | false | `Stats Seen` |
-| `most_used_word_matching_strategy`      | Most used word matching strategy among all search requests in this batch | `last` | `Documents Searched POST`, `Documents Searched GET` |
+| `most_used_matching_strategy`      | Most used word matching strategy among all search requests in this batch | `last` | `Documents Searched POST`, `Documents Searched GET` |
 
 ----
 
@@ -220,7 +220,7 @@ This property allows us to gather essential information to better understand on 
 | formatting.crop_marker | Does `cropMarker` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | formatting.show_matches_position | Does `showMatchesPosition` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | facets | Does `facets` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
-| most_used_word_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
+| most_used_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
 
 ---
 
@@ -249,7 +249,7 @@ This property allows us to gather essential information to better understand on 
 | formatting.crop_marker | Does `cropMarker` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | formatting.show_matches_position | Does `showMatchesPosition` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | facets | Does `facets` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
-| most_used_word_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
+| most_used_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
 
 ---
 

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -135,6 +135,8 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filtered_by_type`                      | `true` if `GET /tasks` endpoint is filered by `type`, otherwise `false` | false | `Tasks Seen` |
 | `filtered_by_status`                    | `true` if `GET /tasks` endpoint is filered by `status`, otherwise `false` | false | `Tasks Seen` |
 | `per_index_uid` | `true` if an uid is used to fetch an index stat resource, otherwise `false` | false | `Stats Seen` |
+| `most_used_word_matching_strategy`      | Most used word matching strategy among all search requests in this batch | `last` | `Documents Searched POST`, `Documents Searched GET` |
+
 ----
 
 #### Detailed list of Instance metrics and, events with their metrics
@@ -218,6 +220,7 @@ This property allows us to gather essential information to better understand on 
 | formatting.crop_marker | Does `cropMarker` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | formatting.show_matches_position | Does `showMatchesPosition` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | facets | Does `facets` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
+| most_used_word_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
 
 ---
 
@@ -246,6 +249,7 @@ This property allows us to gather essential information to better understand on 
 | formatting.crop_marker | Does `cropMarker` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | formatting.show_matches_position | Does `showMatchesPosition` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
 | facets | Does `facets` has been used in the aggregated event? If yes, `true` otherwise `false` | `false` |
+| most_used_word_matching_strategy | Most used word matching strategy among all search requests in the aggregated event. `last` / `all` | `last` |
 
 ---
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -47,7 +47,7 @@ If a master key is used to secure a Meilisearch instance, the auth layer returns
 | [`cropLength`](#3112-croplength)                      | Integer                  | False    |
 | [`cropMarker`](#3113-cropmarker)                      | String                   | False    |
 | [`showMatchesPosition`](#3114-showmatchesposition)    | Boolean                  | False    |
-| [`wordMatchingStrategy](#3115-wordMatchingStrategy)   | String                   | False    |
+| [`matchingStrategy](#3115-matchingStrategy)           | String                   | False    |
 
 #### 3.1.1. `q`
 
@@ -648,7 +648,7 @@ It's useful when more control is needed than offered by the built-in highlightin
 
 - 🔴 Sending a value with a different type than `Boolean` or `null` for `showMatchesPosition` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
-#### 3.1.15. `wordMatchingStrategy`
+#### 3.1.15. `matchingStrategy`
 
 - Type: String
 - Required: False
@@ -658,7 +658,7 @@ Defines which strategy to use to match the query terms within the documents as s
 
 Two different strategies are available, `last` and `all`. By default, the `last` strategy is chosen.
 
-- 🔴 Sending a value with a different type than `String` and other than `last` or `all` as a value for `wordMatchingStrategy` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
+- 🔴 Sending a value with a different type than `String` and other than `last` or `all` as a value for `matchingStrategy` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
 ##### 3.1.15.1. `last` strategy
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -31,22 +31,23 @@ If a master key is used to secure a Meilisearch instance, the auth layer returns
 
 ### 3.1. Search Payload Parameters
 
-| Field                                                 | Type                      | Required |
-|-------------------------------------------------------|---------------------------|----------|
-| [`q`](#311-q)                                         | String                    | False    |
-| [`filter`](#312-filter)                               | Array of String - String  | False    |
-| [`sort`](#313-sort)                                   | Array of String - String  | False    |
-| [`facets`](#314-facets)                               | Array of String - String  | False    |
-| [`limit`](#315-limit)                                 | Integer                   | False    |
-| [`offset`](#316-offset)                               | Integer                   | False    |
-| [`attributesToRetrieve`](#317-attributestoretrieve)   | Array of String - String  | False    |
-| [`attributesToHighlight`](#318-attributestohighlight) | Array of String - String  | False    |
-| [`highlightPreTag`](#319-highlightpretag)             | String                    | False    |
-| [`highlightPostTag`](#3110-highlightposttag)          | String                    | False    |
-| [`attributesToCrop`](#3111-attributestocrop)          | Array of String - String  | False    |
-| [`cropLength`](#3112-croplength)                      | Integer                   | False    |
-| [`cropMarker`](#3113-cropmarker)                      | String                    | False    |
-| [`showMatchesPosition`](#3114-showmatchesposition)                | Boolean                   | False    |
+| Field                                                 | Type                     | Required |
+|-------------------------------------------------------|--------------------------|----------|
+| [`q`](#311-q)                                         | String                   | False    |
+| [`filter`](#312-filter)                               | Array of String - String | False    |
+| [`sort`](#313-sort)                                   | Array of String - String | False    |
+| [`facets`](#314-facets)                               | Array of String - String | False    |
+| [`limit`](#315-limit)                                 | Integer                  | False    |
+| [`offset`](#316-offset)                               | Integer                  | False    |
+| [`attributesToRetrieve`](#317-attributestoretrieve)   | Array of String - String | False    |
+| [`attributesToHighlight`](#318-attributestohighlight) | Array of String - String | False    |
+| [`highlightPreTag`](#319-highlightpretag)             | String                   | False    |
+| [`highlightPostTag`](#3110-highlightposttag)          | String                   | False    |
+| [`attributesToCrop`](#3111-attributestocrop)          | Array of String - String | False    |
+| [`cropLength`](#3112-croplength)                      | Integer                  | False    |
+| [`cropMarker`](#3113-cropmarker)                      | String                   | False    |
+| [`showMatchesPosition`](#3114-showmatchesposition)    | Boolean                  | False    |
+| [`wordMatchingStrategy](#3115-wordMatchingStrategy)   | String                   | False    |
 
 #### 3.1.1. `q`
 
@@ -647,18 +648,37 @@ It's useful when more control is needed than offered by the built-in highlightin
 
 - 🔴 Sending a value with a different type than `Boolean` or `null` for `showMatchesPosition` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
+#### 3.1.15. `wordMatchingStrategy`
+
+- Type: String
+- Required: False
+- Default: `last`
+
+Defines which strategy to use to match the query terms within the documents as search results.
+
+Two different strategies are available, `last` and `all`. By default, the `last` strategy is chosen.
+
+- 🔴 Sending a value with a different type than `String` and other than `last` or `all` as a value for `wordMatchingStrategy` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
+
+##### 3.1.15.1. `last` strategy
+
+The documents containing ALL the query words (i.e. in the `q` parameter) are returned first by Meilisearch. If Meilisearch doesn't have enough documents to fit the requested `limit`, it iteratively ignores the query words from the last typed word to the first typed word to match more documents.
+
+##### 3.1.15.2. `all` strategy
+
+Only the documents containing ALL the query words (i.e. in the `q` parameter) are returned by Meilisearch. If Meilisearch doesn't have enough documents to fit the requested `limit`, it returns the documents found without trying to match more documents.
 
 ### 3.2. Search Response Properties
 
-| Field                                                 | Type                         | Required |
-|-------------------------------------------------------|------------------------------|----------|
-| [`hits`](#321-hits)                                   | Array[Hit]                   | True     |
-| [`limit`](#322-limit)                                 | Integer                      | True     |
-| [`offset`](#323-offset)                               | Integer                      | True     |
-| [`estimatedTotalHits`](#324-estimatedTotalHits)       | Integer                      | True     |
-| [`facetDistribution`](#325-facetdistribution)       | Object                       | False    |
-| [`processingTimeMs`](#326-processingtimems)           | Integer                      | True     |
-| [`query`](#327-query)                                 | String                       | True     |
+| Field                                           | Type       | Required |
+|-------------------------------------------------|------------|----------|
+| [`hits`](#321-hits)                             | Array[Hit] | True     |
+| [`limit`](#322-limit)                           | Integer    | True     |
+| [`offset`](#323-offset)                         | Integer    | True     |
+| [`estimatedTotalHits`](#324-estimatedTotalHits) | Integer    | True     |
+| [`facetDistribution`](#325-facetdistribution)   | Object     | False    |
+| [`processingTimeMs`](#326-processingtimems)     | Integer    | True     |
+| [`query`](#327-query)                           | String     | True     |
 
 #### 3.2.1. `hits`
 
@@ -675,11 +695,11 @@ A search result can contain special properties. See [3.2.1.1. `hit` Special Prop
 
 ##### 3.2.1.1. `hit` Special Properties
 
-| Field                                | Type        | Required |
-|--------------------------------------|-------------|----------|
-| [`_geoDistance`](#32111-geodistance) | Integer     | False    |
-| [`_formatted`](#32112-formatted)     | Object      | False    |
-| [`_matchesPosition`](#32113-matchesposition) | Object      | False    |
+| Field                                        | Type    | Required |
+|----------------------------------------------|---------|----------|
+| [`_geoDistance`](#32111-geodistance)         | Integer | False    |
+| [`_formatted`](#32112-formatted)             | Object  | False    |
+| [`_matchesPosition`](#32113-matchesposition) | Object  | False    |
 
 ###### 3.2.1.1.1. `_geoDistance`
 


### PR DESCRIPTION
🤖  [API Diff](https://github.com/meilisearch/specifications/pull/173#issuecomment-1222297686)

---

# Summary

Implement the ability to choose a word matching strategy at search time between `last` and `all` strategies.

We know that some users are still stuck in pre-v0.21 versions because of the hard implementation of the `last` mode introduced with v0.21. We are confident that adding the `all` strategy will permit those users to move to the newer versions while giving more versatility to Meilisearch regarding relevancy tweaking.

---

# Changes

- Add a `matchingStrategy` parameter to POST and GET `search` endpoints
      - `last` is the default strategy if the field is not specified
      - 2 strategies are available: `last` and `all`.
- `most_used_matching_strategy` is added as a telemetry node on POST and GET `/search` events.

# Out Of Scope

Proposing and introducing other modes than `all` and `last` is out-of-scope. A [product discussion](https://github.com/meilisearch/product/discussions/255) exists to collect and discuss other strategies.

---

# Attention To Reviewers

- ~~@meilisearch/docs-team `wordMatchingStrategy` parameter can change. We also proposed `termMatchingStrategy`. Please validate/correct this proposal or propose another one that seems more suited if you have a better idea 💡~~ **(addressed in the following comments)**
- ~~@meilisearch/core-team @meilisearch/integration-team Should we put this parameter in a parent object at search to accommodate other fields related to this topic in the future? There is a **good chance** we will propose this parameter as an index setting in the future. Storing this parameter and other related parameters in a parent-object avoids generating a new API route per parameters on the settings side, which could impact the search endpoints regarding consistency and thus add a breaking change if we don't do it now.~~ **(addressed in the following comments)**

Example:

`wordMatching` is just an example; there may be a better name for that parent object concept.

At search:

```jsonc
{
      "wordMatching": {
            "wordMatchingStrategy": "all",
            "disablePrefixSearchOnAttributes": ["title", ...] //exemple of a potential future,
            "...": ...
      }
}
```

If needed, SDKs could still implement facade methods to obfuscate the `wordMatching` parent.

Doing so would permit us to easily add new fields in the future while keeping a well-organized API matching the index settings.

In index settings API: 

`GET - /indexes/:indexUid/settings/wordMatching`
`PATCH - /indexes/:indexUid/settings/wordMatching` 
`DELETE - /indexes/:indexUid/settings/wordMatching`

Instead of: 

`GET - /indexes/:indexUid/settings/wordMatchingStrategy`
`GET - /indexes/:indexUid/settings/disabledPrefixSearchOnAttributes`
`PUT - /indexes/:indexUid/settings/wordMatchingStrategy`
`PUT- /indexes/:indexUid/settings/disabledPrefixSearchOnAttributes`
`DELETE - /indexes/:indexUid/settings/wordMatchingStrategy`
`DELETE - /indexes/:indexUid/settings/disabledPrefixSearchOnAttributes`
...

and so on for every field that may be added in the future that could have been organized under a parent object scoping the same "layer".

WDYT?

---

## Misc

- [x] Update OpenAPI specification file
- [x] Update telemetry datapoints
