### PR TITLE
Keys API - Indicate to users that a master key must be set at Meilisearch launch to use that feature 

### DIFF
--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1350,6 +1350,29 @@ HTTP Code: `403 Forbidden`
 
 ---
 
+## missing_master_key
+
+`Synchronous`
+
+### Context
+
+For some specific protected routes (i.e. `/keys`) the master key must be defined before accessing it. This error indicates to the user that he must first define a master key when launching Meilisearch.
+
+### Error Definition
+
+HTTP Code: `401 Forbidden`
+
+```json
+{
+    "message": "Meilisearch is running without a master key. To access this API endpoint, you must have set a master key at launch.",
+    "code": "missing_master_key",
+    "type": "auth",
+    "link": "https://docs.meilisearch.com/errors#missing_master_key"
+}
+```
+
+---
+
 ## 2. Technical details
 N/A
 

--- a/text/0085-api-keys.md
+++ b/text/0085-api-keys.md
@@ -201,6 +201,7 @@ Gives the total number of API keys that can be browsed.
 
 ###### 3.2.4.2.3. Errors
 
+- 🔴 Accessing this route while a master key is not set for the instance returns a [missing_master_key](0061-error-format-and-definitions.md#missing_master_key) error.
 - 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
 - 🔴 Accessing this route without the master key returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 
@@ -279,6 +280,7 @@ See [API Key Resource Representation](#3241-api-key-resource-representation) sec
 
 ###### 3.2.4.3.3. Errors
 
+- 🔴 Accessing this route while a master key is not set for the instance returns a [missing_master_key](0061-error-format-and-definitions.md#missing_master_key) error.
 - 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
 - 🔴 Accessing this route without the master key or an API key missing the `keys.get` permission returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 
@@ -330,6 +332,7 @@ See [API Key Resource Representation](#3241-api-key-resource-representation) sec
 
 ###### 3.2.4.4.3. Errors
 
+- 🔴 Accessing this route while a master key is not set for the instance returns a [missing_master_key](0061-error-format-and-definitions.md#missing_master_key) error.
 - 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
 - 🔴 Accessing this route without the master key or an API key missing the `keys.create` permission returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 - 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
@@ -368,6 +371,7 @@ See [API Key Resource Representation](#3241-api-key-resource-representation) sec
 
 ###### 3.2.4.5.3. Errors
 
+- 🔴 Accessing this route while a master key is not set for the instance returns a [missing_master_key](0061-error-format-and-definitions.md#missing_master_key) error.
 - 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
 - 🔴 Accessing this route without the master key or an API key missing the `keys.update` permission returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 - 🔴 Attempting to access an API key that does not exist returns a [api_key_not_found](0061-error-format-and-definitions.md#api_key_not_found) error.
@@ -395,6 +399,7 @@ Returns a `204 No-Content` HTTP code when the request is successful.
 
 ###### 3.2.4.6.3. Errors
 
+- 🔴 Accessing this route while a master key is not set for the instance returns a [missing_master_key](0061-error-format-and-definitions.md#missing_master_key) error.
 - 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
 - 🔴 Accessing this route without the master key or an API key missing the `keys.delete` permission returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
 - 🔴 Attempting to access an API key that does not exist returns a [`api_key_not_found`](0061-error-format-and-definitions.md#api_key_not_found) error.


### PR DESCRIPTION
# Summary

Following this discussion: https://github.com/meilisearch/product/discussions/552

Indicate to users that a master key must first be defined when launching Meilisearch to access the API Keys management feature.

---

# Changes

- Add a new error: `missing_master_key`
- Update the API Keys specification

---

# Attention To Reviewers
N/A