### PR TITLE
Keys API - Add a variant message when an index uid format is invalid for the indexes field.

### DIFF
--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -294,6 +294,19 @@ HTTP Code: `400 Bad Request`
 
 - The `:value` is inferred when the message is generated.
 
+#### Variant: Sending an invalid index uid format in `indexes` field.
+
+```json
+{
+    "message": "`uid` is not a valid index uid. Index uid can be an integer or a string containing only alphanumeric characters, hyphens (-) and underscores (_).",
+    "code": "invalid_api_key_indexes",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_api_key_indexes"
+}
+```
+
+- The `:uid` is inferred when the message is generated.
+
 ---
 
 ## invalid_api_key_expires_at


### PR DESCRIPTION
Use the `invalid_index_uid` error message as a variant for `invalid_api_key_indexes` error when an invalid index uid is set into the API Key `indexes` field.

### Related issue

https://github.com/meilisearch/meilisearch/issues/2158
https://github.com/meilisearch/meilisearch/issues/2924