### PR TITLE
Instance Options - `localhost:7700` instead of `127.0.0.1:7700`

### DIFF
--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -153,7 +153,7 @@ Configures the instance's environment. Value must be either `production` or `dev
 
 **Environment variable**: `MEILI_HTTP_ADDR`
 **CLI option**: `--http-addr`
-**Default value**: `"127.0.0.1:7700"`
+**Default value**: `"localhost:7700"`
 **Expected value**: an HTTP address and port
 
 Sets the HTTP address and port Meilisearch will use.


### PR DESCRIPTION
# Summary

Replace `127.0.0.1:7700` by `localhost:7700` to match both ipv4 and ipv6 address.

Related to:
- https://github.com/meilisearch/meilisearch/issues/2782
- https://github.com/meilisearch/meilisearch/pull/2861

---

# Changes

See Summary section.

# Out Of Scope
N/A

---

# Attention To Reviewers
N/A

---

## Misc
N/A