### PR TITLE
GitHub Actions - Trigger OpenAPI Diff on `release-v*` branches

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - develop
+      - 'release-v*'
 jobs:
   api-diff:
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Specification workflow now starts from the main branch or a release branch. `develop` should not be needed anymore. 