### PR TITLE
🚧 Search API - Add built-in filter `_geoBoundingBox`

### DIFF
--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -1,47 +1,20 @@
-- Title: Geosearch
-- Start Date: 2021-08-02
-- Specification PR: [#59](https://github.com/meilisearch/specifications/pull/59)
-- Discovery Issue: [#42](https://github.com/meilisearch/product/issues/42)
-
 # Geosearch
 
-## 1. Functional Specification
+## 1. Summary
 
-### I. Summary
+Meilisearch provides geosearch features. It's possible to filter and sort documents based on their geo-spatial coordinates.
 
-The purpose of this specification is to add a first iteration of the **geosearch** feature to give geo-filtering and geosorting capabilities at search time.
+## 2. Motivation
 
-#### Summary Key points
+Some use cases specifically require integrated geosearch capabilities.
 
-- Documents MUST have a `_geo` reserved object to be geosearchable.
-- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`.
-- Filter documents by a given geo bounding box using the built-in filter `_geoBoundingBox([{lat, lng}, {lat, lng}])`.
-- Filter documents by a given geo polygon using the built-in filter `_geoPolygon([{lat, lng}, ...])`
-- It is possible to cumulate several geosearch filters within the `filter` field.
-- Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
-- It is possible to filter and/or sort by geographical criteria of the user's choice.
-- `_geo` must be set as a filterable attribute to use geo filtering capabilities.
-- `_geo` must be set as a sortable attribute to use geo sort capabilities.
-- There is no `geo` ranking rule that can be manipulated by the user. This one is automatically integrated in the ranking rule `sort` by default and activated by sorting using the `_geoPoint({lat}, {lng})` built-in sort rule.
-- Using `_geoPoint({lat}, {lng})` in the `sort` parameter at search leads the engine to return a `_geoDistance` within the search results. This field represents the distance in meters of the document from the specified `_geoPoint`.
-- Add an `invalid_geo_field` error.
-- Add an alternative message for `invalid_sort` and `invalid_filter` error to handle reserved keywords.
-- `invalid_criterion` is renamed to `invalid_ranking_rule` and add an alternative message to handle reserved keywords.
+## 3. Functional Specification
 
-### II. Motivation
+### 3.1. Define Geo-spatial Coordinates
 
-According to our user feedback, the lack of a geosearch feature is mentioned as one of the biggest deal-breakers for choosing Meilisearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geosearch capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geosearch documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which Meilisearch can respond.
+The reserved field `_geo` define coordinates within a document.
 
-### III. Technical Explanations
-
-#### **As a developer, I want to add geospatial coordinates to a document so that the document can be geosearchable.**
-
-- Introduce a reserved field `_geo` for documents to store geo spatial data from an **object** made of `lat` and `lng` fields for a **JSON format**.
-- Introduce a reserved column `_geo` for documents to store geo spatial data from a **string** made of `lat,lng` for a **CSV format**.
-
-##### **JSON Format**
-
-**`_geo` field definition**
+#### 3.1.1. JSON `_geo` Field Definition
 
 - Name: `_geo`
 - Type: Object
@@ -49,12 +22,11 @@ According to our user feedback, the lack of a geosearch feature is mentioned as 
 - Not required
 
 > 💡 if `_geo` is found in the document payload, `lat` and `lng` are required.
-> 💡 `lat` and `lng` must be of float value.
 > 💡 `lat` and `lng` field type can be mixed. e.g. `lat` can be a string while `lng` is a number in the same `_geo` object.
 
-##### **CSV Format**
+#### 3.1.2. CSV `_geo` Column Definition
 
-Following the format already defined in the https://github.com/meilisearch/specifications/pull/28/files specification for document indexing from a CSV format. A reserved column `_geo` can be added to specify the geographical coordinates of a document.
+A reserved column `_geo` can be added to specify the geographical coordinates of a document within a csv file.
 
 csv format example
 ```
@@ -62,218 +34,96 @@ csv format example
 "1","F40","Ferrari","48.862725,2.287592"
 ```
 
-**`_geo` column definition**
-
 - Name: `_geo`
 - Type: String
 - Format: `"lat:float,lng:float"`
 - Not required
 
-#### POST Add or replace documents `/indexes/{indexUid}/documents`
+### 3.2. Enable Geo-search Features
 
-##### Request body
-```json
-[
-    {
-        "id": 1,
-        "label": "F40",
-        "brand": "Ferrari",
-        "_geo": {
-            "lat": 48.862725,
-            "lng": 2.287592
-        }
-    }
-]
-```
+- To filter documents based on their geo-spatial coordinates, the `_geo` field must be defined in the [`filterableAttributes`](0123-filterable-attributes-setting-api.md) index setting.
+- To sort documents based on their geo-spatial coordinates, the `_geo` field must be defined in the [`sortableAttributes`](0123-sortable-attributes-setting-api.md) index setting.
 
-##### 202 Accepted - Response body
+#### 3.2.1. Asynchronous Error
 
-```json
-{
-    "updateId": 1
-}
-```
+As soon as `_geo` is specified in one of these settings, an asynchronous error may occur when indexing a `_geo` field.
 
-#### PUT Add or replace documents `/indexes/{indexUid}/documents`
+- 🔴 Giving a bad formed `_geo` that do not conform to the format returns an [`invalid_geo_field`](0061-error-format-and-definitions#invalid_geo_field) error.
 
-##### Request body
+### 3.3. Filtering Documents
 
-```json
-[
-    {
-        "id": 1,
-        "brand": "F40 LM",
-        "brand": "Ferrari",
-        "_geo": {
-            "lat": "48.862725",
-            "lng": "2.287592"
-        }
-    }
-]
-```
+>  The `_geo` field has to be set in `filterableAttributes` index setting by the developer to activate geo filtering capabilities at search.
 
-##### 202 Accepted - Response body
+The following built-in filter rules can be used as expressions within the `filter` parameter for a search query.
 
-```json
-{
-    "updateId": 2
-}
-```
+#### 3.3.1. Supported Shapes
 
-- 🔴 Giving a bad formed `_geo` that do not conform to the format causes the `update` payload to fail. A new `invalid_geo_field` error is given in the `update` object.
+##### 3.3.1.1. Radius
 
----
-
-### **As an end-user, I want to filter documents within a geo shape.**
-
-#### Available shapes
-
-##### Radius
-
-`_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule  to `filter` documents in a geo radius shape.
-
-**`_geoRadius` built-in filter rule definition**
+`_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule can be used to filter documents in a geo radius shape.
 
 - Name: `_geoRadius`
 - Signature: ({lat:float}:required, {lng:float}:required, {distance_in_meters:int}:required)
 - Not required
 - `distance_in_meters` only accepts positive value.
 
-##### BoundingBox
+##### 3.3.1.2. BoundingBox
 
-`_geoBoundingBox([{{lat1}, {lng1}}, {{lat2, lng2}}])` built-in filter rule to `filter` documents in a geo bounding box shape.
-
-**`_geoBoundingBox` built-in filter rule definition**
+`_geoBoundingBox(({lat}, {lng}), ({lat, lng}))` built-in filter can be used to filter documents in a geo bounding box shape.
 
 - Name: `_geoBoundingBox`
-- Signature: ([{{lat1}, {lng1}}, {{lat2}, {lng2}}]): Array made of 2 geo coordinates object.
+- Signature: (({lat:float}:required, {lng:float}:required), ({lat:float}:required, {lng:float}:required))
 - Not required
 
-##### Polygon
 
-`_geoPolygon([{{lat1}, {lng1}}, {{lat2}, {lng2}}, ...])` built-in filter rule to `filter` documents in a geo polygon shape.
+#### 3.3.2. Errors
 
-**`_geoPolygon` built-in filter rule definition**
+- 🔴 Specifying parameters that do not conform to the `_geoRadius` signature returns an [`invalid_filter`](0061-error-format-and-definitions.md#invalid_filter) error.
+- 🔴 Specifying parameters that do not conform to the `_geoBoundingBox` signature returns an [`invalid_filter`](0061-error-format-and-definitions.md#invalid_filter) error.
+- 🔴 Using `_geoDistance`, `_geo`, or `_geoPoint` in a filter expression returns an [`invalid_filter`](0061-error-format-and-definitions.md#invalid_filter) error.
 
-- Name: `_geoPolygon`
-- Signature: ([{{lat1}, {lng1}}, {{lat2}, {lng2}}, {{lat3}, {lng3}}, ...]): Array made of 3 or more geo coordinates object to form a geo polygon shape.
-- Not required
+### 3.4. Sorting Documents
 
----
+>  The `_geo` field has to be set in `sortableAttributes` index setting by the developer to activate geo sorting capabilities at search.
 
->  The `_geo` field has to be set in `filterableAttributes` setting by the developer to activate geo filtering capabilities at search.
+The following built-in filter rules can be used as expressions within the `sort` parameter for a search query.
 
-#### GET Search `/indexes/{indexUid}/search`
+#### 3.4.1. Sorting Around A Geo Point
 
-```
-...&filter="brand=Mercedes AND _geoRadius(48.862725, 2.287592, 2000)"`
-```
-
-#### POST Search `/indexes/{indexUid}/search`
-
-```json
-{
-    "filter": ["brand = Ferrari", "_geoRadius(48.862725, 2.287592, 2000)"]
-}
-```
-
-- 🔴 Specifying parameters that do not conform to the `_geoRadius` signature causes the API to return an `invalid_filter` error. The error message should indicate how `_geoRadius` should be used. See `_geoRadius` built-in filter rule definition part.
-- 🔴 Using `_geoDistance` in a filter expression causes the API to return an `invalid_filter` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a filter expression.`
-- 🔴 Using `_geo` in a filter expression causes the API to return an `invalid_filter` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a filter expression. Use the _geoRadius(latitude, longitude, distance) built-in rule to filter on _geo field coordinates.`
-- 🔴 Using `_geoPoint` in a filter expression causes the API to return an `invalid_filter` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a filter expression. Use the _geoRadius(latitude, longitude, distance) built-in rule to filter on _geo field coordinates.`
-
----
-
-### **As an end-user, I want to sort documents around a geo point.**
-
-- Introduce a `_geoPoint({lat}, {lng})` function parameter to `sort` documents around a central point.
-
-**`_geoPoint` built-in sort rule definition**
+`_geoPoint({lat}, {lng}):asc|desc` built-in sort can be used to sort documents around a geo-spatial point.
 
 - Name: `_geoPoint`
 - Signature: ({lat:float}:required, {lng:float}:required)
 - Not required
 
-Following the [`sort` specification feature](https://github.com/meilisearch/specifications/pull/55):
-> The `_geo` field has to be set in `sortableAttributes` setting by the developer to activate geo sorting capabilities at search.
+>There is no `geo` ranking rule as such.
 >
->There is no `geo` ranking rule as such. It is in fact within the `sort` ranking rule in an obfuscated way.
->
->`_geoPoint` built-in sort rule can sort documents in ascending/descending order.
+>`_geoPoint` built-in sort rule can sort documents in ascending/descending order e.g. `_geoPoint({lat, lng}):asc` / `_geoPoint({lat, lng}):desc`
 
-#### GET Search `/indexes/{indexUid}/search`
+##### 3.4.1.1. `_geoDistance` Search Result Field
 
-```
-    ...&sort=_geoPoint({lat, lng}):asc,price:desc
-```
-
-#### POST Search `/indexes/{indexUid}/search`
-
-```json
-{
-    "sort": "_geoPoint({lat, lng}):asc,price:desc"
-}
-```
-- 🔴 Specifying parameters that do not conform to the `_geoPoint` signature causes the API to return an `invalid_sort` error. The error message should indicate how `_geoPoint` should be used. See `_geoPoint` built-in sort rule definition part.
-- 🔴 Using `_geoDistance` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression.`
-- 🔴 Using `_geo` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
-- 🔴 Using `_geoRadius` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
-- 🔴 Using `_geoBoundingBox` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
-- 🔴 Using `_geoPolygon` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
----
-
-### **As an end-user, I want to know the document distance when I am sorting around a geo point.**
-
-- Introduce a `_geoDistance` parameter to the search result `hit` object.
-
-**`_geoDistance` field definition**
+When the sort expression `_geoPoint` is used, Meilisearch returns the distance in meters relative to the coordinates of the `_geoPoint` for each search result in a `_geoDistance` field.
 
 - Name: `_geoDistance`
-- Description: Return document distance when the end-user sorts document from a `_geoPoint` in meters.
-- Type: int
+- Description: Return the document distance, in meters, from the specified `_geoPoint` coordinates.
+- Type: Integer
 - Not required
 
-> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. So if the end-user filters documents using a `_geoRadius` built-in filter without sorting them around a `_geoPoint`, this field `_geoDistance` will not appear in the search response.
+> 💡 `_geoDistance` response field is only computed and shown when the end-user have sorted documents around a `_geoPoint`. So if the end-user filters documents using a `_geoRadius`, or a `_geoBoundingBox` filter expression without sorting them around a `_geoPoint`, this field `_geoDistance` will not appear in the search response.
+
+##### 3.4.1.2. Errors
+
+- 🔴 Specifying parameters that do not conform to the `_geoPoint` signature returns an [`invalid_sort`](0061-error-format-and-definitions.md#invalid_sort) error.
+- 🔴 Using `_geoDistance`, `_geo`, `_geoRadius`, or `_geoBoundingBox` in a sort expression returns an [`invalid_sort`](0061-error-format-and-definitions.md#invalid_sort) error.
 
 ---
 
-### `invalid_criterion` error changes
+## 4. Technical Details
+N/A
 
-The error is currently marked as an internal error thus the name is not explicit and consistent with the term `Ranking Rule` a user can encounter in the documentation and in the API resource name. A new definition of this error is proposed.
+## 5. Future Possibilities
 
-#### invalid_ranking_rule
-
-#### Context
-
-This error is raised asynchronously when the user tries to specify an invalid ranking rule in the ranking rules setting.
-
-#### Error Definition
-
-```json
-    "message": ":rankingRule ranking rule is invalid. Valid ranking rules are words, typo, sort, proximity, attribute, exactness and custom ranking rules."
-    "code": "invalid_ranking_rule"
-    "type": "invalid_request"
-    "link": "https://docs.meilisearch.com/errors#invalid_ranking_rule"
-```
-
-- 🔴 Specifying an invalid ranking rule name raises an `invalid_ranking_rule` error. See `message` defined in the error definition part.
-- 🔴 Specifying a custom ranking rule with `_geo` or `_geoDistance` raises an `invalid_ranking_rule` error. The message is `:reservedKeyword is a reserved keyword and thus can't be used as a ranking rule.`.
-- 🔴 Specifying a custom ranking rule with `_geoPoint` raises an `invalid_ranking_rule` error. The message is `_geoPoint is a reserved keyword and thus can't be used as a ranking rule. _geoPoint can only be used for sorting at search time`.
-- 🔴 Specifying a custom ranking rule with `_geoRadius` raises an `invalid_ranking_rule` error. The message is `_geoRadius is a reserved keyword and thus can't be used as a ranking rule. _geoRadius can only be used for filtering at search time`.
-- 🔴 Specifying a custom ranking rule with `_geoBoundingBox` raises an `invalid_ranking_rule` error. The message is `_geoBoundingBox is a reserved keyword and thus can't be used as a ranking rule. _geoBoundingBox can only be used for filtering at search time`.
-- 🔴 Specifying a custom ranking rule with `_geoPolygon` raises an `invalid_ranking_rule` error. The message is `_geoPolygon is a reserved keyword and thus can't be used as a ranking rule. _geoPolygon can only be used for filtering at search time`.
-
----
-
-## 2. Technical Aspects
-
-### I. Measuring
-
-- `filterableAttribute` setting definition to evaluate `_geo` presence.
-- `sortableAttribute` setting definition to evaluate `_geo` presence.
-
-## 3. Future Possibilities
-
+- Support `_geoPolygon` filter
 - Handling array of geo points in the document object.
 - Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geohash etc.
 - Handling distance in other formats (like the imperial format). **It's easy to implement on the user side though.**

--- a/text/0059-geo-search.md
+++ b/text/0059-geo-search.md
@@ -14,7 +14,10 @@ The purpose of this specification is to add a first iteration of the **geosearch
 #### Summary Key points
 
 - Documents MUST have a `_geo` reserved object to be geosearchable.
-- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`. It is possible to cumulate several geosearch filters within the `filter` field.
+- Filter documents by a given geo radius using the built-in filter `_geoRadius({lat}, {lng}, {distance_in_meters})`.
+- Filter documents by a given geo bounding box using the built-in filter `_geoBoundingBox([{lat, lng}, {lat, lng}])`.
+- Filter documents by a given geo polygon using the built-in filter `_geoPolygon([{lat, lng}, ...])`
+- It is possible to cumulate several geosearch filters within the `filter` field.
 - Sort documents in ascending/descending order around a geo point. e.g. `_geoPoint({lat}, {lng}):asc`.
 - It is possible to filter and/or sort by geographical criteria of the user's choice.
 - `_geo` must be set as a filterable attribute to use geo filtering capabilities.
@@ -27,7 +30,7 @@ The purpose of this specification is to add a first iteration of the **geosearch
 
 ### II. Motivation
 
-According to our user feedback, the lack of a geosearch feature is mentioned as one of the biggest deal-breakers for choosing MeiliSearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geosearch capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geosearch documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which MeiliSearch can respond.
+According to our user feedback, the lack of a geosearch feature is mentioned as one of the biggest deal-breakers for choosing Meilisearch as a search engine. A search engine must offer this feature. Some use cases specifically require integrated geosearch capabilities. Moreover, a lot of direct competitors offer it. Users today must find workarounds like using geohash to be able to geosearch documents. We hope to better serve the needs of users by implementing this feature. It allows multiplying the use-cases to which Meilisearch can respond.
 
 ### III. Technical Explanations
 
@@ -121,9 +124,13 @@ csv format example
 
 ---
 
-### **As an end-user, I want to filter documents within a geo radius.**
+### **As an end-user, I want to filter documents within a geo shape.**
 
-- Introduce a `_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule  to `filter` documents in a geo radius.shape.
+#### Available shapes
+
+##### Radius
+
+`_geoRadius({lat}, {lng}, {distance_in_meters})` built-in filter rule  to `filter` documents in a geo radius shape.
 
 **`_geoRadius` built-in filter rule definition**
 
@@ -131,6 +138,28 @@ csv format example
 - Signature: ({lat:float}:required, {lng:float}:required, {distance_in_meters:int}:required)
 - Not required
 - `distance_in_meters` only accepts positive value.
+
+##### BoundingBox
+
+`_geoBoundingBox([{{lat1}, {lng1}}, {{lat2, lng2}}])` built-in filter rule to `filter` documents in a geo bounding box shape.
+
+**`_geoBoundingBox` built-in filter rule definition**
+
+- Name: `_geoBoundingBox`
+- Signature: ([{{lat1}, {lng1}}, {{lat2}, {lng2}}]): Array made of 2 geo coordinates object.
+- Not required
+
+##### Polygon
+
+`_geoPolygon([{{lat1}, {lng1}}, {{lat2}, {lng2}}, ...])` built-in filter rule to `filter` documents in a geo polygon shape.
+
+**`_geoPolygon` built-in filter rule definition**
+
+- Name: `_geoPolygon`
+- Signature: ([{{lat1}, {lng1}}, {{lat2}, {lng2}}, {{lat3}, {lng3}}, ...]): Array made of 3 or more geo coordinates object to form a geo polygon shape.
+- Not required
+
+---
 
 >  The `_geo` field has to be set in `filterableAttributes` setting by the developer to activate geo filtering capabilities at search.
 
@@ -189,7 +218,8 @@ Following the [`sort` specification feature](https://github.com/meilisearch/spec
 - 🔴 Using `_geoDistance` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression.`
 - 🔴 Using `_geo` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
 - 🔴 Using `_geoRadius` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
-
+- 🔴 Using `_geoBoundingBox` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
+- 🔴 Using `_geoPolygon` in a sort expression causes the API to return an `invalid_sort` error. `message` should be `:reservedKeyword is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.`
 ---
 
 ### **As an end-user, I want to know the document distance when I am sorting around a geo point.**
@@ -230,14 +260,10 @@ This error is raised asynchronously when the user tries to specify an invalid ra
 - 🔴 Specifying a custom ranking rule with `_geo` or `_geoDistance` raises an `invalid_ranking_rule` error. The message is `:reservedKeyword is a reserved keyword and thus can't be used as a ranking rule.`.
 - 🔴 Specifying a custom ranking rule with `_geoPoint` raises an `invalid_ranking_rule` error. The message is `_geoPoint is a reserved keyword and thus can't be used as a ranking rule. _geoPoint can only be used for sorting at search time`.
 - 🔴 Specifying a custom ranking rule with `_geoRadius` raises an `invalid_ranking_rule` error. The message is `_geoRadius is a reserved keyword and thus can't be used as a ranking rule. _geoRadius can only be used for filtering at search time`.
+- 🔴 Specifying a custom ranking rule with `_geoBoundingBox` raises an `invalid_ranking_rule` error. The message is `_geoBoundingBox is a reserved keyword and thus can't be used as a ranking rule. _geoBoundingBox can only be used for filtering at search time`.
+- 🔴 Specifying a custom ranking rule with `_geoPolygon` raises an `invalid_ranking_rule` error. The message is `_geoPolygon is a reserved keyword and thus can't be used as a ranking rule. _geoPolygon can only be used for filtering at search time`.
+
 ---
-
-### IV. Finalized Key Changes
-
-- Add a `_geo` reserved field on JSON and CSV format to index a geo point coordinates for a document.
-- Add a `_geoPoint(lat, lng)` built-in sort rule.
-- Add a `_geoRadius(lat, lng, distance_in_meters)` built-in filter rule.
-- Return a `_geoDistance` in `hits` objects representing the distance in meters computed from the `_geoPoint` built-in sort rule.
 
 ## 2. Technical Aspects
 
@@ -248,7 +274,6 @@ This error is raised asynchronously when the user tries to specify an invalid ra
 
 ## 3. Future Possibilities
 
-- Add built-in filter to filter documents within `polygon` and `bounding-box`.
 - Handling array of geo points in the document object.
 - Handling multiple geo formats for the `_geo` field. e.g. "{lat},{lng}", a geohash etc.
 - Handling distance in other formats (like the imperial format). **It's easy to implement on the user side though.**

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -604,27 +604,34 @@ HTTP Code: `400 Bad Request`
 
 - `:attribute` is inferred when the message is generated.
 
-#### Variant: Using `_geoDistance` as a filter expression
+#### Variant: Using a reserved keyword
 
 ```json
 {
-    "message": "`:reservedKeyword` is a reserved keyword and thus can't be used as a filter expression.",
+    "message": "`:reservedKeyword` is a reserved keyword and thus can't be used as a filter expression. Use the `_geoRadius(latitude, longitude, distance), or _geoBoundingBox((latitude, longitude), (latitude, longitude)) built-in rules to filter on `_geo` coordinates.",
     ...
 }
 ```
 
 - The `:reservedKeyword` is inferred when the message is generated.
 
-#### Variant: Using `_geo` or `_geoPoint` as a filter expression
+#### Variant: Sending an invalid latitude for a geo filter
 
 ```json
 {
-    "message": "`:reservedKeyword` is a reserved keyword and thus can't be used as a filter expression. Use the _geoRadius(latitude, longitude, distance) built-in rule to filter on _geo field coordinates.",
+    "message": "Bad latitude {value}. Latitude must be contained between -90 and 90 degrees.",
     ...
 }
 ```
 
-- The `:reservedKeyword` is inferred when the message is generated.
+#### Variant: Sending an invalid longitude for a geo filter
+
+```json
+{
+    "message": "Bad longitude {value}. Longitude must be contained between -180 and 180 degrees.",
+    ...
+}
+```
 
 #### Variant: Invalid syntax for the `filter` parameter
 
@@ -656,9 +663,7 @@ HTTP Code: `400 Bad Request`
 ```json
 {
     "message": "Attribute `:attribute` is not sortable. Available sortable attributes are: `:sortableAttributes`.",
-    "code": "invalid_sort",
-    "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#invalid_sort"
+    ...
 }
 ```
 
@@ -670,15 +675,13 @@ HTTP Code: `400 Bad Request`
 ```json
 {
     "message": "Attribute `:attribute` is not sortable. This index does not have configured sortable attributes.",
-    "code": "invalid_sort",
-    "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#invalid_sort"
+    ...
 }
 ```
 
 - The `:attribute` is inferred when the message is generated.
 
-#### Variant: Using `_geoDistance` as a sort expression
+#### Variant: Using reserved keyword as a sort expression
 
 ```json
 {
@@ -687,9 +690,8 @@ HTTP Code: `400 Bad Request`
 }
 ```
 
-- The `:reservedKeyword` is inferred when the message is generated.
+#### Variant: Using a geo reserved keyword as a sort expression
 
-#### Variant: Using `_geo` or `_geoRadius` as a sort expression
 ```json
 {
     "message": "`:reservedKeyword` is a reserved keyword and thus can't be used as a sort expression. Use the _geoPoint(latitude, longitude) built-in rule to sort on _geo field coordinates.",
@@ -699,11 +701,12 @@ HTTP Code: `400 Bad Request`
 
 - The `:reservedKeyword` is inferred when the message is generated.
 
+
 #### Variant: Invalid syntax for the `sort`parameter
 
 ```json
 {
-    "message": "Invalid syntax for the sort parameter: `:syntaxErrorHelper`.",
+    "message": "Invalid syntax for the sort parameter: expected expression ending by `:asc` or `:desc`, found `{name}`.",
     ...
 }
 ```
@@ -716,6 +719,15 @@ HTTP Code: `400 Bad Request`
 {
     "message": "The sort ranking rule must be specified in the ranking rules settings to use the sort parameter at search time.",
     ...
+}
+```
+
+#### Variant: Invalid `_geoPoint` expression
+
+```json
+{
+    "message": "Invalid syntax for the geo parameter: expected expression formated like `_geoPoint(latitude, longitude)` and ending by `:asc` or `:desc`, found `{name}`.",
+    ...,
 }
 ```
 
@@ -735,7 +747,7 @@ These errors occurs when the `_geo` field of a document payload is not valid. Ei
 
 ```json
 {
-    "message": "The `_geo` field in the document with the id: `:documentId` is not an object. Was expecting an object with the `_geo.lat` and `_geo.lng` fields but instead got `:field`.",
+    "message": "The `_geo` field in the document with the id: `{document_id}` is not an object. Was expecting an object with the `_geo.lat` and `_geo.lng` fields but instead got `{value}`.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
@@ -746,29 +758,62 @@ These errors occurs when the `_geo` field of a document payload is not valid. Ei
 
 ```json
 {
-    "message": "Could not find latitude nor longitude in the document with the id: `:documentId`. Was expecting `_geo.lat` and `_geo.lng` fields.",
+    "message": "Could not find latitude nor longitude in the document with the id: `{document_id}`. Was expecting `_geo.lat` and `_geo.lng` fields.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
 }
 ```
 
-#### Variant: Missing `_geo.lat` **or** `_geo.lng` field.
+#### Variant: Missing `_geo.lat` field.
 
 ```json
 {
-    "message": "Could not find :coord in the document with the id: `:documentId`. Was expecting a `:field` field.",
+    "message": "Could not find latitude in the document with the id: `:documentId`. Was expecting a `_geo.lat` field.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
 }
 ```
 
-#### Variant: Coordinate can't be parsed.
+#### Variant: Missing `_geo.lng` field.
 
 ```json
 {
-    "message": "Could not parse :coord in the document with the id: `:documentId`. Was expecting a finite number but instead got `:value`.",
+    "message": "Could not find longitude in the document with the id: `:documentId`. Was expecting a `_geo.lng` field.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+#### Variant: Latitude and longitude can't be parsed.
+
+```json
+{
+    "message": "Could not parse latitude nor longitude in the document with the id: `{document_id}`. Was expecting finite numbers but instead got `{lat}` and `{lng}`.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+#### Variant: Latitude can't be parsed.
+
+```json
+{
+    "message": "Could not parse latitude in the document with the id: `{document_id}`. Was expecting a finite number but instead got `{value}`.",
+    "code": "invalid_geo_field",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
+}
+```
+
+#### Variant: Longitude can't be parsed.
+
+```json
+{
+    "message": "Could not parse longitude in the document with the id: `{document_id}`. Was expecting a finite number but instead got `{value}`.",
     "code": "invalid_geo_field",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#invalid_geo_field"
@@ -776,8 +821,6 @@ These errors occurs when the `_geo` field of a document payload is not valid. Ei
 ```
 
 - The `:documentId` is inferred when the message is generated.
-- The `:coord` is either `latitude` or `longitude` depending on what's wrong.
-- The `:field` is either `_geo.lat` or `_geo.lng` depending on what's wrong.
 
 ---
 

--- a/text/0123-ranking-rules-setting-api.md
+++ b/text/0123-ranking-rules-setting-api.md
@@ -159,6 +159,10 @@ See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-t
 > Otherwise, Meilisearch will create the index in a lazy way. See [3.2.2.4. Lazy Index Creation](#3224-lazy-index-creation).
 
 - 🔴 Sending an invalid ranking rule returns an [invalid_ranking_rule](0061-error-format-and-definitions.md#invalid_ranking_rule) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
+- 🔴 Specifying a custom ranking rule containing `_geo` or `_geoDistance` returns an [invalid_ranking_rule](0061-error-format-and-definitions.md#invalid_ranking_rule) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
+- 🔴 Specifying a custom ranking rule containing `_geoPoint` returns an [invalid_ranking_rule](0061-error-format-and-definitions.md#invalid_ranking_rule) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
+- 🔴 Specifying a custom ranking rule containing `_geoRadius` returns an [invalid_ranking_rule](0061-error-format-and-definitions.md#invalid_ranking_rule) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
+- 🔴 Specifying a custom ranking rule containing `_geoBoundingBox` returns an [invalid_ranking_rule](0061-error-format-and-definitions.md#invalid_ranking_rule) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
 
 ##### 3.3.2.4. Lazy Index Creation
 


### PR DESCRIPTION
# Summary

- Add the `_geoBoundingBox(({lat}, {lng), {lat}, {lng))` filter expression
- Rewrites the original spec in a long-term format
- Catch up on every missing variant introduced without the spec being kept up to date :rage1: :rage2: :rage3: :rage4: :feelsgood: for `invalid_geo_field`, `invalid_sort` and `invalid_filter` errors

---

# Changes
N/A


# Out Of Scope
N/A

---

# Attention To Reviewers

- Double-check the error variants.

---

## Misc

- [] Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_
- [] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
