### PR TITLE
 Rename dump command from `--dumps-dir` to `--dump-dir`

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1227,7 +1227,7 @@ paths:
       operationId: dumps.create
       summary: Create a Dump
       description: |
-        Triggers a dump creation process. Once the process is complete, a dump is created in the [dumps directory](https://docs.meilisearch.com/reference/features/configuration.html#dumps-destination). If the dumps directory does not exist yet, it will be created.
+        Triggers a dump creation process. Once the process is complete, a dump is created in the [dump directory](https://docs.meilisearch.com/reference/features/configuration.html#dumps-destination). If the dump directory does not exist yet, it will be created.
       tags:
         - Dumps
       security:

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1227,7 +1227,7 @@ paths:
       operationId: dumps.create
       summary: Create a Dump
       description: |
-        Triggers a dump creation process. Once the process is complete, a dump is created in the [dump directory](https://docs.meilisearch.com/reference/features/configuration.html#dumps-destination). If the dump directory does not exist yet, it will be created.
+        Triggers a dump creation process. Once the process is complete, a dump is created in the [dump directory](https://docs.meilisearch.com/reference/features/configuration.html#dump-directory). If the dump directory does not exist yet, it will be created.
       tags:
         - Dumps
       security:

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -76,7 +76,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `infos.env`                             | MeiliSearch env                                         | production        | Every hour   |
 | `infos.db_path`                         | `true` if `--db-path`/`MEILI_DB_PATH` is specified, otherwise `false` | true | Every Hour |
 | `infos.import_dump`                     | `true` if `--import-dump` is specified, otherwise `false` | true | Every Hour |
-| `infos.dumps_dir`                       | `true` if `--dumps-dir`/`MEILI_DUMPS_DIR` is specified, otherwise `false` | true | Every Hour |
+| `infos.dump_dir`                       | `true` if `--dump-dir`/`MEILI_DUMP_DIR` is specified, otherwise `false` | true | Every Hour |
 | `infos.ignore_missing_dump`             | `true` if `--ignore-missing-dump` is specified to true, otherwise `false` | true | Every Hour |
 | `infos.ignore_dump_if_db_exists`        | `true` if `--ignore-dump-if-db-exists` is specified to true, otherwise `false` | true | Every Hour |
 | `infos.import_snapshot`                 | `true` if `--import-snapshot` is specified, otherwise `false` | true | Every Hour |
@@ -173,7 +173,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filtered_by_before_finished_at`        | `true` if tasks are filtered by the `beforeFinishedAt` query parameter, otherwise `false` | false | `Tasks Seen`, `Tasks Canceled`, `Tasks Deleted` |
 | `filtered_by_after_finished_at`         | `true` if tasks are filtered by the `afterFinishedAt` query parameter, otherwise `false` | false | `Tasks Seen`, `Tasks Canceled`, `Tasks Deleted` |
 | `per_index_uid` | `true` if an uid is used to fetch an index stat resource, otherwise `false` | false | `Stats Seen` |
-| `swap_operation_number`            | The number of swap operation given in `POST /swap-indexes` API call | 2 | `Indexes Swapped` | 
+| `swap_operation_number`            | The number of swap operation given in `POST /swap-indexes` API call | 2 | `Indexes Swapped` |
 | `matching_strategy.most_used_strategy`      | Most used word matching strategy among all search requests in this batch | `last` | `Documents Searched POST`, `Documents Searched GET` |
 | `per_document_id` | `true` if `DELETE /indexes/:indexUid/documents/:documentUid` endpoint was used in this batch, otherwise `false` | false | `Documents Deleted` |
 | `clear_all` | `true` if `DELETE /indexes/:indexUid/documents` endpoint was used in this batch, otherwise `false` | false | `Documents Deleted` |
@@ -204,7 +204,7 @@ This property allows us to gather essential information to better understand on 
 | infos.env | Value of `--env`/`MEILI_ENV` | `production` |
 | infos.db_path | `true` if `--db-path`/`MEILI_DB_PATH` is specified, otherwise `false` | `true`|
 | infos.import_dump | `true` if `--import-dump` is specified, otherwise `false` | `true` |
-| infos.dumps_dir | `true` if `--dumps-dir`/`MEILI_DUMPS_DIR` is specified, otherwise `false` | `true` |
+| infos.dump_dir | `true` if `--dump-dir`/`MEILI_DUMP_DIR` is specified, otherwise `false` | `true` |
 | infos.ignore_missing_dump | `true` if `--ignore-missing-dump` is specified to true, otherwise `false` | `true` |
 | infos.ignore_dump_if_db_exists | `true` if `--ignore-dump-if-db-exists` is specified to true, otherwise `false` | `true` |
 | infos.import_snapshot | `true` if `--import-snapshot` is specified, otherwise `false` | `true` |

--- a/text/0105-dumps-api.md
+++ b/text/0105-dumps-api.md
@@ -16,7 +16,7 @@ The dumps exist to upgrade a MeiliSearch instance from a previous version to a m
 - A dump creation status can be tracked using the `GET - /tasks/:task_uid` endpoint.
 - MeiliSearch can only create one dump at a time.
 - By default, dumps are created in a folder named `dumps`, and can be found in the same directory as the MeiliSearch binary.
-- The `dumps` directory can be customized using the `--dumps-dir` configuration option. If the dump directory does not already exist when the dump creation process is called, MeiliSearch will create it.
+- The `dumps` directory can be customized using the `--dump-dir` configuration option. If the dump directory does not already exist when the dump creation process is called, MeiliSearch will create it.
 - A `.dump` file can be imported using the `--import-dump` command-line flag.
 - The MeiliSearch server starts when the dump is fully imported and indexed.
 - By default, importing a dump when a database already exists (a non-empty data.ms folder in the same directory as the MeiliSearch binary) will stop the process and throw an error.
@@ -54,11 +54,11 @@ The uid of the generated dump can be found in the task details.
 
 ### 3.3. CLI Definition
 
-#### 3.3.1. `--dumps-dir`
+#### 3.3.1. `--dump-dir`
 
 By default, MeiliSearch creates dumps in a directory called `dumps` at the root of your MeiliSearch.
 
-The destination can be modified with the `--dumps-dir` flag. e.g. `--dumps-dir myDumps`
+The destination can be modified with the `--dump-dir` flag. e.g. `--dump-dir myDumps`
 
 #### 3.3.2. `--import-dump`
 

--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -184,7 +184,7 @@ If no master key is provided in a `development` environment, all routes will be 
 
 Deactivates Meilisearch's built-in telemetry collect when enabled.
 
-#### 3.3.6. Dump destination
+#### 3.3.6. Dump directory
 
 **Environment variable**: `MEILI_DUMP_DIR`
 **CLI option**: `--dump-dir`

--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -96,7 +96,7 @@ The expected behavior of each flag is described in the list above.
 - [HTTP address & port binding](#333-http-address--port-binding)
 - [Master key](#334-master-key)
 - [Disable analytics](#335-disable-analytics)
-- [Dumps destination](#336-dumps-destination)
+- [Dump destination](#336-dump-destination)
 - [Import dump](#337-import-dump)
 - [Ignore missing dump](#338-ignore-missing-dump)
 - [Ignore dump if DB exists](#339-ignore-dump-if-db-exists)
@@ -184,10 +184,10 @@ If no master key is provided in a `development` environment, all routes will be 
 
 Deactivates Meilisearch's built-in telemetry collect when enabled.
 
-#### 3.3.6. Dumps destination
+#### 3.3.6. Dump destination
 
-**Environment variable**: `MEILI_DUMPS_DIR`
-**CLI option**: `--dumps-dir`
+**Environment variable**: `MEILI_DUMP_DIR`
+**CLI option**: `--dump-dir`
 **Default value**: `dumps/`
 **Expected value**: a filepath pointing to a valid directory
 

--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -96,7 +96,7 @@ The expected behavior of each flag is described in the list above.
 - [HTTP address & port binding](#333-http-address--port-binding)
 - [Master key](#334-master-key)
 - [Disable analytics](#335-disable-analytics)
-- [Dump destination](#336-dump-destination)
+- [Dump directory](#336-dump-directory)
 - [Import dump](#337-import-dump)
 - [Ignore missing dump](#338-ignore-missing-dump)
 - [Ignore dump if DB exists](#339-ignore-dump-if-db-exists)


### PR DESCRIPTION
🤖  [API Diff]() _Put the link of the GitHub comment generated by bump.sh if generated; Apply the `OpenApi` label_

---

# Summary

Propagate the changes of https://github.com/meilisearch/meilisearch/pull/3175

---

# Changes

- uses of `dumps foo` as a compound noun are replaced by `dump foo`

## Telemetry Changes

- `infos.dumps_dir` property is renamed `infos.dump_dir`

# Out Of Scope

N/A

---

# Attention To Reviewers

- I did not update the link to the website: https://docs.meilisearch.com/reference/features/configuration.html#dumps-destination, we could want `dump-destination` as the header here, and this might be inconsistent with me renaming that header in the spec itself (`3.3.6. Dump destination` in `text/0119-instance-options.md`

---

## Misc

- [] Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_
- [] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
