### PR TITLE
Remove `--max-index-size` and `--max-task-db-size`

### DIFF
--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -86,8 +86,6 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `infos.ignore_missing_snapshot`         | `true` if `--ignore_missing_snapshot` is specified to true, otherwise `false` | true | Every Hour |
 | `infos.ignore_snapshot_if_db_exists`    | `true` if `--ignore_snapshot_if_db_exists` is specified to true, otherwise `false` | true | Every Hour |
 | `infos.http_addr`                       | `true` if `--http-addr`/`MEILI_HTTP_ADDR` is specified, otherwise `false` | true| Every Hour |
-| `infos.max_index_size`                  | Value of `--max-index-size`/`MEILI_INDEX_SIZE` in bytes | 336042103 | Every Hour |
-| `infos.max_task_db_size`                | Value of `--max-task-db-size`/`MEILI_MAX_TASK_DB_SIZE` in bytes | 336042103 | Every Hour |
 | `infos.http_payload_size_limit`         | Value of `--http-payload-size-limit`/`MEILI_HTTP_PAYLOAD_SIZE_LIMIT` in bytes | 336042103 | Every Hour |
 | `infos.disable_auto_batching`            | `true` if `--disable-auto-batching`/`MEILI_DISABLE_AUTO_BATCHING` is specified to true, otherwise `false` | `true` | Every Hour |
 | `infos.log_level`                       | Value of `--log-level`/`MEILI_LOG_LEVEL`                | debug             | Every Hour |
@@ -173,7 +171,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filtered_by_before_finished_at`        | `true` if tasks are filtered by the `beforeFinishedAt` query parameter, otherwise `false` | false | `Tasks Seen`, `Tasks Canceled`, `Tasks Deleted` |
 | `filtered_by_after_finished_at`         | `true` if tasks are filtered by the `afterFinishedAt` query parameter, otherwise `false` | false | `Tasks Seen`, `Tasks Canceled`, `Tasks Deleted` |
 | `per_index_uid` | `true` if an uid is used to fetch an index stat resource, otherwise `false` | false | `Stats Seen` |
-| `swap_operation_number`            | The number of swap operation given in `POST /swap-indexes` API call | 2 | `Indexes Swapped` | 
+| `swap_operation_number`            | The number of swap operation given in `POST /swap-indexes` API call | 2 | `Indexes Swapped` |
 | `matching_strategy.most_used_strategy`      | Most used word matching strategy among all search requests in this batch | `last` | `Documents Searched POST`, `Documents Searched GET` |
 | `per_document_id` | `true` if `DELETE /indexes/:indexUid/documents/:documentUid` endpoint was used in this batch, otherwise `false` | false | `Documents Deleted` |
 | `clear_all` | `true` if `DELETE /indexes/:indexUid/documents` endpoint was used in this batch, otherwise `false` | false | `Documents Deleted` |
@@ -214,8 +212,6 @@ This property allows us to gather essential information to better understand on 
 | infos.ignore_missing_snapshot | `true` if `--ignore-missing-snapshot` is specified to true, otherwise `false` | `true` |
 | infos.ignore_snapshot_if_db_exists | `true` if `--ignore-snapshot-if-db-exists` is specified to true, otherwise `false` | `true` |
 | infos.http_addr | `true` if `--http-addr`/`MEILI_HTTP_ADDR` is specified, otherwise `false` | `true`|
-| infos.max_index_size | Value of `--max-index-size`/`MEILI_INDEX_SIZE` in bytes | `336042103` |
-| infos.max_task_db_size | Value of `--max-task-db-size`/`MEILI_MAX_TASK_DB_SIZE` in bytes | `336042103` |
 | infos.http_payload_size_limit | Value of `--http-payload-size-limit`/`MEILI_HTTP_PAYLOAD_SIZE_LIMIT` in bytes | `336042103` |
 | infos.disable_auto_batching | `true` if `--disable-auto-batching`/`MEILI_DISABLE_AUTO_BATCHING` is specified to true, otherwise `false` | `true` |
 | infos.log_level | Value of `--log-level`/`MEILI_LOG_LEVEL`  | `debug` |

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -534,23 +534,19 @@ HTTP Code: `404 Not Found`
 
 - The `:taskUid` is inferred when the message is generated.
 
-#### 8. `MEILI_MAX_TASK_DB_SIZE` env var and `--max-task-db-size` CLI option
-
-See [0119-instance-options](0119-instance-options.md##3312-max-taskdb-size)
-
-#### 9. Asynchronous Write Operations on Index resource
+#### 8. Asynchronous Write Operations on Index resource
 
 - 💡 Automatic index creation using the `/indexes/:indexToCreate/documents` route generates a `documentAdditionOrUpdate` task that also handles index creation.
 
-#### 10. Paginate `task` resource lists
+#### 9. Paginate `task` resource lists
 
 The API endpoint `GET /tasks` is browsable using a keyset-based pagination.
 
-##### 10.1. Why a Seek/Keyset based pagination?
+##### 9.1. Why a Seek/Keyset based pagination?
 
 Keyset-based pagination is more appropriate when the data can grow or shrink quickly in terms of magnitude.
 
-###### 10.1.1. Pros
+###### 9.1.1. Pros
 
 The performance is better than the not-so-good but old pagination with `offset`/`limit`.
 
@@ -558,11 +554,11 @@ Seek/Keyset pagination keeps the results consistent between each page as the dat
 
 Moreover, the performance is superior to traditional pagination since the computational complexity remains constant to reach the identifier marking the beginning of the new slice to be returned from a hash table.
 
-###### 10.1.2. Cons
+###### 9.1.2. Cons
 
 The main drawback of this type of pagination is that it does not navigate within a finite number of pages. It is also limited to a precise sorting criterion on unique identifiers ordered sequentially.
 
-##### 10.2. Response attributes
+##### 9.2. Response attributes
 
 | field | type | description                          |
 |-------|------|--------------------------------------|
@@ -570,14 +566,14 @@ The main drawback of this type of pagination is that it does not navigate within
 | from | integer | The first task uid returned |
 | next | integer - nullable  | Represents the value to send in `from` to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order. |
 
-##### 10.3. GET query parameters
+##### 9.3. GET query parameters
 
 | field | type | required | description  |
 |-------|------|----------|--------------|
 | limit | integer  | No       | Default `20`. Limit on the number of tasks to be returned. |
 | from | integer  | No       | Limit results to tasks with uids equal to and lower than this uid. |
 
-##### 10.4. Usage examples
+##### 9.4. Usage examples
 
 This part demonstrates keyset paging in action on `/tasks`. The items `uid` remains sorted sequentially and can be used to navigate a list of `tasks` objects.
 
@@ -666,26 +662,26 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
 
 - 💡 `next` response parameter is null because there are no more `tasks` to fetch. It means that the response represents the last slice of results for the given resource list.
 
-##### 10.5. Behaviors for `limit` and `from` query parameters
+##### 9.5. Behaviors for `limit` and `from` query parameters
 
-###### 10.5.1. `limit`
+###### 9.5.1. `limit`
 
 - If `limit` is not set, the default value is chosen.
 
-###### 10.5.2. `from`
+###### 9.5.2. `from`
 
 - If `from` is set with an out of bounds task `uid`, the response returns the tasks that are the nearest to the specified uid, the `next` field is set to the next page. It will be equivalent to call the `/tasks` route without any parameter.
 
-###### 10.5.3. Errors
+###### 9.5.3. Errors
 
 - 🔴 Sending a value with a different type than `Integer` for `limit` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 - 🔴 Sending a value with a different type than `Integer` for `from` returns a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
-#### 11. Filtering task resources
+#### 10. Filtering task resources
 
 The tasks API endpoints are filterable by  `uids`, `indexUids`, `types`, `statuses`, `canceledBy`, `beforeEnqueuedAt`, `afterEnqueuedAt`, `beforeStartedAt`, `afterStartedAt`, `beforeFinishedAt`,  `afterFinishedAt` query parameters.
 
-##### 11.1 Query parameters definition
+##### 10.1 Query parameters definition
 
 | parameter | type   | required | description                                                                                                                                                                                                                             |
 |-----------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -701,9 +697,9 @@ The tasks API endpoints are filterable by  `uids`, `indexUids`, `types`, `status
 | beforeFinishedAt | string | No       | Filter tasks based on their finishedAt time. Retrieve tasks finished before the given filter value.  |
 | afterFinishedAt | string | No       | Filter tasks based on their finishedAt time. Retrieve tasks finished after the given filter value.                 |
 
-##### 11.2. Query Parameters Behaviors
+##### 10.2. Query Parameters Behaviors
 
-###### 11.2.1. `uids`
+###### 10.2.1. `uids`
 
  Filter tasks by their related unique identifier. By default, when `uids` query parameter is not set, all the tasks are concerned. It is possible to specify several uid by separating them with the `,` character.
 
@@ -715,7 +711,7 @@ The tasks API endpoints are filterable by  `uids`, `indexUids`, `types`, `status
 
 - 🔴 Sending values with a different type than `Integer` being separated by `,` for the `uid` parameter returns an [`invalid_task_uids_filter`](0061-error-format-and-definitions.md#invalid_task_uids_filter) error.
 
-###### 11.2.2. `indexUids`
+###### 10.2.2. `indexUids`
 
 Filter tasks by their related index. By default, when `indexUids` query parameter is not set, the tasks of all the indexes are concerned. It is possible to specify several indexUids by separating them with the `,` character.
 
@@ -725,7 +721,7 @@ Filter tasks by their related index. By default, when `indexUids` query paramete
 
 `indexUids` is **case-sensitive**.
 
-###### 11.2.3. `statuses`
+###### 10.2.3. `statuses`
 
 Filter tasks by their status. By default, when `statuses` query parameter is not set, all task statuses are concerned. It's possible to specify several statuses by separating them with the `,` character.
 
@@ -737,7 +733,7 @@ Filter tasks by their status. By default, when `statuses` query parameter is not
 
 - 🔴 If the `statuses` parameter value is not consistent with one of the task statuses, an [`invalid_task_statuses_filter`](0061-error-format-and-definitions.md#invalid_task_statuses_filter) error is returned.
 
-###### 11.2.4. `types`
+###### 10.2.4. `types`
 
 Filter tasks by their related type. By default, when `types` query parameter is not set, all task types are concerned. It's possible to specify several types by separating them with the `,` character.
 
@@ -749,7 +745,7 @@ Filter tasks by their related type. By default, when `types` query parameter is 
 
 - 🔴 If the `types` parameter value is not consistent with one of the task types, an [`invalid_task_types_filter`](0061-error-format-and-definitions.md#invalid_task_types_filter) error is returned.
 
-###### 11.2.5. `canceledBy`
+###### 10.2.5. `canceledBy`
 
 Filter tasks by the `taskCancelation` uid that canceled them. It's possible to specify several task uids by separating them with the `,` character.
 
@@ -761,7 +757,7 @@ Filter tasks by the `taskCancelation` uid that canceled them. It's possible to s
 
 - 🔴Sending a value with a different type than `Integer` for the `canceledBy` parameter returns an [`invalid_task_canceled_by_filter`](0061-error-format-and-definitions.md#invalid_task_canceled_by_filter) error.
 
-###### 11.2.6. Date Parameters
+###### 10.2.6. Date Parameters
 
 Date filters accepts the RFC 3339 format. The following syntaxes are valid:
 
@@ -769,7 +765,7 @@ Date filters accepts the RFC 3339 format. The following syntaxes are valid:
 - `YYYY-MM-DDTHH:MM:SSZ`
 - `YYYY-MM-DDTHH:MM:SS+01:00`
 
-###### 11.2.6.1. `beforeEnqueuedAt` and `afterEnqueuedAt`
+###### 10.2.6.1. `beforeEnqueuedAt` and `afterEnqueuedAt`
 
 Filter tasks based on their enqueuedAt time. Retrieve tasks enqueued before/after the given filter value.
 
@@ -780,7 +776,7 @@ Filter tasks based on their enqueuedAt time. Retrieve tasks enqueued before/afte
 - 🔴 The date filters are exclusive. It means the given value will not be included.
 - 🔴 Sending an invalid value for the date parameter returns an [`invalid_task_date_filter`](0061-error-format-and-definitions.md#invalid_task_date_filter) error.
 
-###### 11.2.6.2. `beforeStartedAt` and `afterStartedAt`
+###### 10.2.6.2. `beforeStartedAt` and `afterStartedAt`
 
 Filter tasks based on their startedAt time. Retrieve tasks started before/after the given filter value.
 
@@ -791,7 +787,7 @@ Filter tasks based on their startedAt time. Retrieve tasks started before/after 
 - 🔴 The date filters are exclusive. It means the given value will not be included.
 - 🔴 Sending an invalid value for the date parameter returns an [`invalid_task_date_filter`](0061-error-format-and-definitions.md#invalid_task_date_filter) error.
 
-###### 11.2.6.3. `beforeFinishedAt` and `afterFinishedAt`
+###### 10.2.6.3. `beforeFinishedAt` and `afterFinishedAt`
 
 Filter tasks based on their finishedAt time. Retrieve tasks finished before/after the given filter value.
 
@@ -803,7 +799,7 @@ Filter tasks based on their finishedAt time. Retrieve tasks finished before/afte
 - 🔴 Sending an invalid value for the date parameter returns an [`invalid_task_date_filter`](0061-error-format-and-definitions.md#invalid_task_date_filter) error.
 
 
-###### 11.2.7. Select multiple values for the same filter
+###### 10.2.7. Select multiple values for the same filter
 
 It is possible to specify multiple values for a filter using the `,` character.
 
@@ -811,7 +807,7 @@ For example, to select the `enqueued` and `processing` tasks of the `movies` and
 
 ---
 
-##### 11.3. Usages examples
+##### 10.3. Usages examples
 
 This part demonstrates filtering on `/tasks`.
 
@@ -986,7 +982,7 @@ This part demonstrates filtering on `/tasks`.
 
 ---
 
-##### 11.4. Empty `results`
+##### 10.4. Empty `results`
 
 If no results match the filters. A response is returned with an empty `results` array.
 

--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -101,26 +101,24 @@ The expected behavior of each flag is described in the list above.
 - [Ignore missing dump](#338-ignore-missing-dump)
 - [Ignore dump if DB exists](#339-ignore-dump-if-db-exists)
 - [Log level](#3310-log-level)
-- [Max index size](#3311-max-index-size)
-- [Max TASK_DB size](#3312-max-task_db-size)
-- [Payload limit size](#3313-payload-limit-size)
-- [Schedule snapshot creation](#3314-schedule-snapshot-creation)
-- [Snapshot destination](#3315-snapshot-destination)
-- [Snapshot interval](#3316-snapshot-interval)
-- [Import snapshot](#3317-import-snapshot)
-- [Ignore missing snapshot](#3318-ignore-missing-snapshot)
-- [Ignore snapshot if DB exists](#3319-ignore-snapshot-if-db-exists)
-- [Max memory usage when indexing](#3320-max-memory-usage-when-indexing)
-- [Max indexing threads](#3321-max-indexing-threads)
-- [Disable auto-batching](#3322-disable-auto-batching)
-- [SSL authentication path](#3323-ssl-authentication-path)
-- [SSL certificates path](#3324-ssl-certificates-path)
-- [SSL key path](#3325-ssl-key-path)
-- [SSL OCSP path](#3326-ssl-ocsp-path)
-- [SSL require auth](#3327-ssl-require-auth)
-- [SSL resumption](#3328-ssl-resumption)
-- [SSL tickets](#3329-ssl-tickets)
-- [Config file path](#3330-config-file-path)
+- [Payload limit size](#3311-payload-limit-size)
+- [Schedule snapshot creation](#3312-schedule-snapshot-creation)
+- [Snapshot destination](#3313-snapshot-destination)
+- [Snapshot interval](#3314-snapshot-interval)
+- [Import snapshot](#3315-import-snapshot)
+- [Ignore missing snapshot](#3316-ignore-missing-snapshot)
+- [Ignore snapshot if DB exists](#3317-ignore-snapshot-if-db-exists)
+- [Max memory usage when indexing](#3318-max-memory-usage-when-indexing)
+- [Max indexing threads](#3319-max-indexing-threads)
+- [Disable auto-batching](#3320-disable-auto-batching)
+- [SSL authentication path](#3321-ssl-authentication-path)
+- [SSL certificates path](#3322-ssl-certificates-path)
+- [SSL key path](#3323-ssl-key-path)
+- [SSL OCSP path](#3324-ssl-ocsp-path)
+- [SSL require auth](#3325-ssl-require-auth)
+- [SSL resumption](#3326-ssl-resumption)
+- [SSL tickets](#3327-ssl-tickets)
+- [Config file path](#3328-config-file-path)
 
 #### 3.3.1. Database path
 
@@ -243,29 +241,7 @@ More information in this [section of the spec](https://github.com/meilisearch/sp
 
 Defines how much detail should be present in Meilisearch's logs.
 
-#### 3.3.11. Max index size
-
-**Environment variable**: `MEILI_MAX_INDEX_SIZE`
-**CLI option**: `--max-index-size`
-**Default value**: `107374182400` (100 GiB)
-**Expected value**: an integer (`104857600`) or a human readable size (`100Mb`)
-
-Sets the maximum size for an index. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
-
-The `index` stores processed data and is different from the `task` database, which handles pending tasks.
-
-#### 3.3.12. Max TASK_DB size
-
-**Environment variable**: `MEILI_MAX_TASK_DB_SIZE`
-**CLI option**: `--max-task-db-size`
-**Default value**: `107374182400` (100 GiB)
-**Expected value**: an integer (`104857600`) or a human readable size (`100Mb`)
-
-Sets the maximum size of the `task` database. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
-
-The `task` database handles pending tasks. This is different from the `index` database, which only stores processed data.
-
-#### 3.3.13. Payload limit size
+#### 3.3.11. Payload limit size
 
 **Environment variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
 **CLI option**: `--http-payload-size-limit`
@@ -274,7 +250,7 @@ The `task` database handles pending tasks. This is different from the `index` da
 
 Sets the maximum size of accepted payloads. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
-#### 3.3.14. Schedule snapshot creation
+#### 3.3.12. Schedule snapshot creation
 
 **Environment variable**: `MEILI_SCHEDULE_SNAPSHOT`
 **CLI option**: `--schedule-snapshot`
@@ -284,7 +260,7 @@ Sets the maximum size of accepted payloads. Value must be given in bytes or expl
 
 Activates scheduled snapshots when enabled. Snapshots are disabled by default.
 
-#### 3.3.15. Snapshot destination
+#### 3.3.13. Snapshot destination
 
 **Environment variable**: `MEILI_SNAPSHOT_DIR`
 **CLI option**: `--snapshot-dir`
@@ -293,7 +269,7 @@ Activates scheduled snapshots when enabled. Snapshots are disabled by default.
 
 Sets the directory where Meilisearch will store snapshots. If the directory does not exist when a snapshot is generated it will be created.
 
-#### 3.3.16. Snapshot interval
+#### 3.3.14. Snapshot interval
 
 **Environment variable**: `MEILI_SNAPSHOT_INTERVAL_SEC`
 **CLI option**: `--snapshot-interval-sec`
@@ -302,7 +278,7 @@ Sets the directory where Meilisearch will store snapshots. If the directory does
 
 Defines the interval between each snapshot. Value must be given in seconds.
 
-#### 3.3.17. Import snapshot
+#### 3.3.15. Import snapshot
 
 **Environment variable**: `MEILI_IMPORT_SNAPSHOT`
 **CLI option**: `--import-snapshot`
@@ -318,7 +294,7 @@ This command will throw an error if:
 
 This behavior can be modified with the `--ignore-snapshot-if-db-exists` and `--ignore-missing-snapshot` options, respectively.
 
-#### 3.3.18. Ignore missing snapshot
+#### 3.3.16. Ignore missing snapshot
 
 **Environment variable**: `MEILI_IGNORE_MISSING_SNAPSHOT`
 **CLI option**: `--ignore-missing-snapshot`
@@ -330,7 +306,7 @@ Prevents a Meilisearch instance from throwing an error when `--import-snapshot` 
 
 This command will throw an error if `--import-snapshot` is not defined.
 
-#### 3.3.19. Ignore snapshot if DB exists
+#### 3.3.17. Ignore snapshot if DB exists
 
 **Environment variable**: `MEILI_IGNORE_SNAPSHOT_IF_DB_EXISTS`
 **CLI option**: `--ignore-snapshot-if-db-exists`
@@ -342,7 +318,7 @@ Prevents a Meilisearch instance with an existing database from throwing an error
 
 This command will throw an error if `--import-snapshot` is not defined.
 
-#### 3.3.20. Max memory usage when indexing
+#### 3.3.18. Max memory usage when indexing
 
 **Environment variable**: `MEILI_MAX_INDEXING_MEMORY`
 **CLI option**: `--max-indexing-memory`
@@ -358,7 +334,7 @@ Value must be given in bytes or explicitly stating a base unit. For example, the
 - This command-line option does not perfectly ensure the RAM usage but helps you manage multiple Meilisearch engines on the same machine (for example, using Kubernetes). The search engine cannot guarantee the exact usage of the RAM.
 - If the number set is higher than the real available RAM in the machine, we cannot prevent Meilisearch from crashing.
 
-#### 3.3.21. Max indexing threads
+#### 3.3.19. Max indexing threads
 
 **Environment variable**: `MEILI_MAX_INDEXING_THREADS`
 **CLI option**: `--max-indexing-threads`
@@ -374,7 +350,7 @@ Obviously, multi-threading is not possible in machines with only one processor c
 
 If the number set is higher than the real number of core available in the machine, Meilisearch will use the maximum number of available cores.
 
-#### 3.3.22. Disable auto-batching
+#### 3.3.20. Disable auto-batching
 
 **Environment variable**: `MEILI_DISABLE_AUTO_BATCHING`
 **CLI option**: `--disable-auto-batching`
@@ -384,7 +360,7 @@ If the number set is higher than the real number of core available in the machin
 
 Disable the [auto-batching feature](./0096-auto-batching.md).
 
-#### 3.3.23. SSL authentication path
+#### 3.3.21. SSL authentication path
 
 **Environment variable**: `MEILI_SSL_AUTH_PATH`
 **CLI option**: `--ssl-auth-path`
@@ -393,7 +369,7 @@ Disable the [auto-batching feature](./0096-auto-batching.md).
 
 Enables client authentication in the specified path.
 
-#### 3.3.24. SSL certificates path
+#### 3.3.22. SSL certificates path
 
 **Environment variable**: `MEILI_SSL_CERT_PATH`
 **CLI option**: `--ssl-cert-path`
@@ -404,7 +380,7 @@ Sets the server's SSL certificates.
 
 Value must be a path to PEM-formatted certificates. The first certificate should certify the KEYFILE supplied by `--ssl-key-path`. The last certificate should be a root CA.
 
-#### 3.3.25. SSL key path
+#### 3.3.23. SSL key path
 
 **Environment variable**: `MEILI_SSL_KEY_PATH`
 **CLI option**: `--ssl-key-path`
@@ -415,7 +391,7 @@ Sets the server's SSL keyfiles.
 
 Value must be a path to an RSA private key or PKCS8-encoded private key, both in PEM format.
 
-#### 3.3.26. SSL OCSP path
+#### 3.3.24. SSL OCSP path
 
 **Environment variable**: `MEILI_SSL_OCSP_PATH`
 **CLI option**: `--ssl-ocsp-path`
@@ -426,7 +402,7 @@ Sets the server's OCSP file. *Optional*
 
 Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
 
-#### 3.3.27. SSL require auth
+#### 3.3.25. SSL require auth
 
 **Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
 **CLI option**: `--ssl-require-auth`
@@ -438,7 +414,7 @@ Makes SSL authentication mandatory.
 
 Sends a fatal alert if the client does not complete client authentication.
 
-#### 3.3.28. SSL resumption
+#### 3.3.26. SSL resumption
 
 **Environment variable**: `MEILI_SSL_RESUMPTION`
 **CLI option**: `--ssl-resumption`
@@ -448,7 +424,7 @@ Sends a fatal alert if the client does not complete client authentication.
 
 Activates SSL session resumption.
 
-#### 3.3.29. SSL tickets
+#### 3.3.27. SSL tickets
 
 **Environment variable**: `MEILI_SSL_TICKETS`
 **CLI option**: `--ssl-tickets`
@@ -458,7 +434,7 @@ Activates SSL session resumption.
 
 Activates SSL tickets.
 
-#### 3.3.30. Config file path
+#### 3.3.28. Config file path
 
 **Environment variable**: `MEILI_CONFIG_FILE_PATH`
 **CLI option**: `--config-file-path`


### PR DESCRIPTION
No API change

---

# Summary

Update specification after removal of the `--max-index-size` and `--max-task-db-size` flags as per https://github.com/meilisearch/meilisearch/issues/3231

---

# Changes

- update CLI arguments to account for removed flags
- renumber a lot of sections as a result

# Out Of Scope

- The soft-deleted documents still reference the removed flags in this PR. This change is covered in #206.

---

# Attention To Reviewers

N/A

---

## Misc

- [] Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_
- [] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
