### PR TITLE
Robustify Primary Key Inference - Update related errors

### DIFF
--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -429,7 +429,7 @@ This error happens when a user tries to update an index primary key while the in
 
 ---
 
-## primary_key_no_candidate_found
+## index_primary_key_no_candidate_found
 
 `Asynchronous`
 
@@ -442,15 +442,15 @@ This error occurs when the engine does not find an identifier in the payload doc
 ```json
 {
     "message": "The primary key inference process failed because the engine did not find any field ending with `id` in its name. Please specify the primary key manually using the `primaryKey` query parameter.",
-    "code": "primary_key_no_candidate_found",
+    "code": "index_primary_key_no_candidate_found",
     "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#primary_key_no_candidate_found"
+    "link": "https://docs.meilisearch.com/errors#index_primary_key_no_candidate_found"
 }
 ```
 
 ---
 
-## primary_key_multiple_candidates_found
+## index_primary_key_multiple_candidates_found
 
 `Asynchronous`
 
@@ -459,9 +459,9 @@ This error occurs when the engine does not find an identifier in the payload doc
 ```json
 {
     "message": "The primary key inference process failed because the engine found `:numCandidates` fields ending with `id` in their name, such as '`:firstCandidate`' and '`:secondCandidate`'. Please specify the primary key manually using the `primaryKey` query parameter.",
-    "code": "primary_key_multiple_candidates_found",
+    "code": "index_primary_key_multiple_candidates_found",
     "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#primary_key_multiple_candidates_found"
+    "link": "https://docs.meilisearch.com/errors#index_primary_key_multiple_candidates_found"
 }
 ```
 

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -429,7 +429,7 @@ This error happens when a user tries to update an index primary key while the in
 
 ---
 
-## primary_key_inference_failed
+## primary_key_no_candidate_found
 
 `Asynchronous`
 
@@ -441,12 +441,32 @@ This error occurs when the engine does not find an identifier in the payload doc
 
 ```json
 {
-    "message": "The primary key inference process failed because the engine did not find any fields containing `id` substring in their name. If your document identifier does not contain any `id` substring, you can set the primary key of the index.",
-    "code": "primary_key_inference_failed",
+    "message": "The primary key inference process failed because the engine did not find any field ending with `id` in its name. Please specify the primary key manually using the `primaryKey` query parameter.",
+    "code": "primary_key_no_candidate_found",
     "type": "invalid_request",
-    "link": "https://docs.meilisearch.com/errors#primary_key_inference_failed"
+    "link": "https://docs.meilisearch.com/errors#primary_key_no_candidate_found"
 }
 ```
+
+---
+
+## primary_key_multiple_candidates_found
+
+`Asynchronous`
+
+### Error Definition
+
+```json
+{
+    "message": "The primary key inference process failed because the engine found `:numCandidates` fields ending with `id` in their name, such as '`:firstCandidate`' and '`:secondCandidate`'. Please specify the primary key manually using the `primaryKey` query parameter.",
+    "code": "primary_key_multiple_candidates_found",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#primary_key_multiple_candidates_found"
+}
+```
+
+- The `:numCandidates` is inferred when the message is generated. It is the number of fields that could serve as a primary key according to the engine's inference rules.
+- The `:firstCandidate` and `:secondCandidate` are inferred when the message is generated. They are the name of two of the fields that could serve as a primary key according to the engine's inference rules.
 
 ---
 

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -441,7 +441,7 @@ This error occurs when the engine does not find an identifier in the payload doc
 
 ```json
 {
-    "message": "The primary key inference process failed because the engine did not find any field ending with `id` in its name. Please specify the primary key manually using the `primaryKey` query parameter.",
+    "message": "The primary key inference failed as the engine did not find any field ending with `id` in its name. Please specify the primary key manually using the `primaryKey` query parameter.",
     "code": "index_primary_key_no_candidate_found",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#index_primary_key_no_candidate_found"
@@ -458,7 +458,7 @@ This error occurs when the engine does not find an identifier in the payload doc
 
 ```json
 {
-    "message": "The primary key inference process failed because the engine found `:numCandidates` fields ending with `id` in their name, such as '`:firstCandidate`' and '`:secondCandidate`'. Please specify the primary key manually using the `primaryKey` query parameter.",
+    "message": "The primary key inference failed as the engine found `:numCandidates` fields ending with `id` in their names: '`:firstCandidate`' and '`:secondCandidate`'. Please specify the primary key manually using the `primaryKey` query parameter.",
     "code": "index_primary_key_multiple_candidates_found",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#index_primary_key_multiple_candidates_found"


### PR DESCRIPTION
No API changes

---

# Summary

Update the errors that can be returned when inference fails following the changes made in https://github.com/meilisearch/meilisearch/pull/3269.

Related to https://github.com/meilisearch/meilisearch/issues/3233.

---

# Changes

- Replace `primary_key_inference_failed` with `primary_key_no_candidate_found` and `primary_key_multiple_candidates_found`.

# Out Of Scope

N/A

---

# Attention To Reviewers

N/A

---

## Misc

- [] Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_
- [] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
