### PR TITLE
Introduce the `--generate-master-key` cli-flag

### DIFF
--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -468,6 +468,17 @@ Define the config file to load at Meilisearch launch.
 
 See [Configuration File](0185-configuration-file.md) specification details.
 
+
+#### 3.3.31. Generate master-key
+
+**Environment variable**: `MEILI_GENERATE_MASTER_KEY`
+**CLI option**: `--generate-master-key`
+**Default**: Disabled
+
+⚠️ This command-line option does not take any values. Assigning a value will throw an error.
+
+Generate a safe to use master key and exit without error.
+
 ## 4. Technical Aspects
 
 N/A


### PR DESCRIPTION
Associated issue; https://github.com/meilisearch/meilisearch/issues/3287
Associated PR; https://github.com/meilisearch/specifications/pull/209

---

# Summary

Introduce the `--generate-master-key` cli-flag.
It generates a cryptographically safe to use master-key.

# Changes

Introduce the `--generate-master-key` cli-flag

# Attention To Reviewers

Should we really introduce an env-var + allow this parameter to be specified with the config file?

