### PR TITLE
Add `OFF` log level to spec

### DIFF
--- a/text/0033-logging.md
+++ b/text/0033-logging.md
@@ -138,6 +138,7 @@ Instead of using `RUST_LOG`, we create a `MEILI_LOG_LEVEL` environment variable 
 | INFO  | Default Log Level. It displays high level informations of events occuring in the search engine.                   |
 | DEBUG | Used for debugging and development purposes.  More verbose than INFO.                                             |
 | TRACE | Display everything happening at engine level. Can be useful for rust developers dealing with complex issues       |
+| OFF   | Disable the logs.                                                                                                 |
 
 
 ##### Log Format
@@ -149,7 +150,7 @@ Instead of using `RUST_LOG`, we create a `MEILI_LOG_LEVEL` environment variable 
 ###### Mandatory log format part. E.g [TIME_FORMAT LOG_LEVEL MODULE] part.
 
 - Time when the request was started to process (in rfc3339 format)
-- Log levels are  `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.
+- Log levels are  `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `OFF`.
 - The module part gives information about the module that records the log.
 
 ###### HTTP Call

--- a/text/0119-instance-options.md
+++ b/text/0119-instance-options.md
@@ -239,7 +239,7 @@ More information in this [section of the spec](https://github.com/meilisearch/sp
 **Environment variable**: `MEILI_LOG_LEVEL`
 **CLI option**: `--log-level`
 **Default value**: `'INFO'`
-**Expected value**: one of `ERROR`, `WARN`, `INFO`, `DEBUG`, OR `TRACE`
+**Expected value**: one of `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, or `OFF`
 
 Defines how much detail should be present in Meilisearch's logs.
 


### PR DESCRIPTION
Add the missing `OFF` value to the logger. 

It already was present before v1, so I don't know where we should merge this. (into `main` or into `release-v1.0.0`)