### PR TITLE
Documents API — Support a csv delimiter customization

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1041,6 +1041,13 @@ components:
           type: string
         example: 'uid,createdAt'
         default: '*'
+    csvDelimiter:
+      name: csvDelimiter
+      in: query
+      description: 'Customize the csv delimiter when importing CSV documents. By default its a comma ","'
+      schema:
+        type: string
+        default: ','
     Content-Type:
       name: Content-Type
       in: header
@@ -1588,6 +1595,8 @@ paths:
           name: Content-Type
           required: true
           description: The content-type associated with the format to be indexed
+        - $ref: '#/components/parameters/primaryKey'
+        - $ref: '#/components/parameters/csvDelimiter'
     put:
       operationId: indexes.documents.upsert
       summary: Add or update documents
@@ -1649,6 +1658,8 @@ paths:
           name: Content-Type
           description: The content-type associated with the format to be indexed
           required: true
+        - $ref: '#/components/parameters/primaryKey'
+        - $ref: '#/components/parameters/csvDelimiter'
     delete:
       operationId: indexes.documents.removeAll
       summary: Delete all documents

--- a/text/0028-indexing-csv.md
+++ b/text/0028-indexing-csv.md
@@ -171,7 +171,7 @@ curl \
 - 🔴 Sending a payload excessing the limit will lead to a 413 Payload Too Large - **payload_too_large** error code.
 - 🔴 Sending an invalid CSV format will lead to a 400 bad_request - **malformed_payload** error code.
 - 🔴 Sending a CSV header that does not conform to the specification will lead to a 400 bad_request - **malformed_payload** error code.
-- 🔴 Sending an invalid csv delimiter: not exactly one ASCII char. This will lead to a 400 bad_request - **invalid_index_csv_delimiter** error code.
+- 🔴 Sending an invalid csv delimiter: not exactly one ASCII char. This will lead to a 400 bad_request - **invalid_document_csv_delimiter** error code.
 
 ##### Errors Definition
 

--- a/text/0028-indexing-csv.md
+++ b/text/0028-indexing-csv.md
@@ -19,6 +19,7 @@ Also, in order to boost write performance CSV data format is more suited than JS
 
 - The header of the csv payload allows to name the attributes and type them.
 - `text/csv` Content-Type header is now supported.
+- A new query parameter, `csvDelimiter`, has been introduced to customize the csv delimiter used in the document. It can change between two `documentAddition`.
 - The error cases have been strengthened and completed. See Errors part.
 
 ### II. Motivation
@@ -43,11 +44,15 @@ While there's [RFC 4180](https://tools.ietf.org/html/rfc4180) as a try to add a 
 
 - The following CSV lines will represent a document for Meilisearch.
 - A `,` character must separate each cell.
-- A CSV value should be enclosed in double-quotes when it contains a comma character or a newline to escape it.
+- A CSV value should be enclosed in double-quotes when it contains the delimiter character or a newline to escape it.
 - Using double-quotes to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote as mentioned in [RFC 4180](https://tools.ietf.org/html/rfc4180).
 - Float value should be written with a `.` character, like `3.14`.
 - CSV text should be encoded in UTF8.
 - The format can't handle array cell values. We are providing `nd-json` format to deal with theses types of attribute in a easier way.
+- A `csvDelimiter` query parameter is available to customize the delimiter used in the documents.
+  - This `csvDelimiter` is optional. By default, the `,` character is used.
+  - The separator must be one [ascii char](https://www.rfc-editor.org/rfc/rfc20).
+  - The separator can't be used with another Content-Type, or else it'll throw an error.
 
 ##### `null` value
 
@@ -166,6 +171,7 @@ curl \
 - 🔴 Sending a payload excessing the limit will lead to a 413 Payload Too Large - **payload_too_large** error code.
 - 🔴 Sending an invalid CSV format will lead to a 400 bad_request - **malformed_payload** error code.
 - 🔴 Sending a CSV header that does not conform to the specification will lead to a 400 bad_request - **malformed_payload** error code.
+- 🔴 Sending an invalid csv delimiter: not exactly one ASCII char. This will lead to a 400 bad_request - **invalid_index_csv_delimiter** error code.
 
 ##### Errors Definition
 

--- a/text/0028-indexing-csv.md
+++ b/text/0028-indexing-csv.md
@@ -273,4 +273,3 @@ n/a
 
 - Provide an interface in the future dashboard to upload CSV data into an index and optionally provide the headers types.
 - Set a payload limit directly related to the type of data format. Currently, the payload size is equivalent to [JSON payload size](https://docs.meilisearch.com/reference/features/configuration.html#payload-limit-size). Metrics on feature usage and configuration update should help to choose a better suited value for this type of data format.
-- Accepts more common CSV separators

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -2765,7 +2765,7 @@ HTTP Code: `401 Forbidden`
 
 ---
 
-## invalid_index_csv_delimiter
+## invalid_document_csv_delimiter
 
 `Synchronous`
 
@@ -2780,9 +2780,9 @@ HTTP Code: `400 Bad Request`
 ```json
 {
     "message": "Invalid value in parameter `csvDelimiter`: expected a string of one character, but found the following string of 5 characters: `doggo`",
-    "code": "invalid_index_csv_delimiter",
+    "code": "invalid_document_csv_delimiter",
     "type": "invalid_request"
-    "link": "https://docs.meilisearch.com/errors#invalid_index_csv_delimiter",
+    "link": "https://docs.meilisearch.com/errors#invalid_document_csv_delimiter",
 }```
 
 ---

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -2765,6 +2765,28 @@ HTTP Code: `401 Forbidden`
 
 ---
 
+## invalid_index_csv_delimiter
+
+`Synchronous`
+
+### Context
+
+The csv delimiter must be exactly one char long, and this char must be an ASCII character.
+
+### Error Definition
+
+HTTP Code: `400 Bad Request`
+
+```json
+{
+    "message": "Invalid value in parameter `csvDelimiter`: expected a string of one character, but found the following string of 5 characters: `doggo`",
+    "code": "invalid_index_csv_delimiter",
+    "type": "invalid_request"
+    "link": "https://docs.meilisearch.com/errors#invalid_index_csv_delimiter",
+}```
+
+---
+
 ## 2. Technical details
 n/a
 


### PR DESCRIPTION
# Summary

Specify the usage of the new query parameter `csvDelimiter` that lets you customize the csv delimiter you wants to use in your document addition.

---

# Attention To Reviewers

Added the `primaryKey` in the OpenAPI schema as a catch up

---

## Misc

- [x] Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_
- [] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
- Implemented in https://github.com/meilisearch/meilisearch/pull/3505