### PR TITLE
Filter operators - `IS NULL` and `IS EMPTY` filter operators

### DIFF
--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -360,7 +360,7 @@ attribute != value1 AND attribute != value2 AND ...
 - The `_geoRadius` operator selects the documents whose geographical coordinates fall within a certain range of a given coordinate. See [GeoSearch](0059-geo-search.md) for more information.
 - The `_geoBoundingBox` operator selects the documents whose geographical coordinates fall within a square described by the given coordinates. See [GeoSearch](0059-geo-search.md) for more information.
 
-###### 3.1.2.1.13 IS EMPTY
+###### 3.1.2.1.12 IS EMPTY
 
 The `IS EMPTY` operator selects the documents for which the filterable attribute exists and is empty. If the attribute doesn't exists then it is not empty and the document will not be returned. It is a postfix operator that takes an attribute name as argument.
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -159,6 +159,12 @@ The grammar for the value of a filterable attribute is the same as the grammar f
 - In:
     * `attribute IN[value, value, etc.]`
     * `attribute NOT IN[value, value, etc.]`
+- IS NULL:
+    * `attribute IS NULL`
+    * `attribute IS NOT NULL`
+- IS EMPTY:
+    * `attribute IS EMPTY`
+    * `attribute IS NOT EMPTY`
 - AND: `filter AND filter`
 - OR: `filter OR filter`
 - NOT: `NOT filter`
@@ -372,6 +378,42 @@ is equivalent to:
 {
     "filter": "(genres = Comedy OR genres = Romance) AND (director = 'Mati Diop')"
 }
+```
+
+###### 3.1.2.1.13 Is Empty
+
+The `IS EMPTY` operator selects the documents for which the filterable attribute exists and is empty. If the attribute doesn't exists then it is not empty and the document will not be returned. It is a postfix operator that takes an attribute name as argument.
+
+The negated form of `IS EMPTY` can be written in two ways:
+```
+attribute IS NOT EMPTY
+NOT attribute IS EMPTY
+```
+Both forms are equivalent. They select the documents for which the attribute is not empty.
+
+For example, with the documents:
+```json
+[{
+    "id": 0,
+    "colour": []
+},
+{
+    "id": 1,
+    "colour": null
+},
+{
+    "id": 2,
+    "colour": ""
+},
+{
+    "id": 3,
+    "colour": {}
+},
+{
+    "id": 4
+}]
+```
+Then the filter `colour IS EMPTY` selects the document ids `[0,2,3]` while the filter `colour IS NOT EMPTY` or `NOT colour IS EMPTY` selects the document ids `[1,4]`.
 ```
 
 #### 3.1.3. `sort`

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -304,7 +304,7 @@ size = 0 OR NOT size = 2                   -> selects [0,1]
 NOT (NOT size = 0)                         -> selects [0]
 ```
 
-###### 3.1.2.1.10 Exists
+###### 3.1.2.1.10 EXISTS
 
 The `EXISTS` operator selects the documents for which the filterable attribute exists, even if its value is `null` or an empty array. It is a postfix operator that takes an attribute name as argument.
 
@@ -331,7 +331,7 @@ For example, with the documents:
 ```
 Then the filter `colour EXISTS` selects the document ids `[0,1]` while the filter `colour NOT EXISTS` or `NOT colour EXISTS` selects the document ids `[2]`.
 
-###### 3.1.2.1.11 In
+###### 3.1.2.1.11 IN
 
 The `IN[..]` operator is a more concise way to combine equality operators. It is a postfix operator that takes an attribute name on the left hand side and an array of values on the right hand side. An array of value is a comma-separated list of values delimited by square brackets.
 
@@ -360,27 +360,7 @@ attribute != value1 AND attribute != value2 AND ...
 - The `_geoRadius` operator selects the documents whose geographical coordinates fall within a certain range of a given coordinate. See [GeoSearch](0059-geo-search.md) for more information.
 - The `_geoBoundingBox` operator selects the documents whose geographical coordinates fall within a square described by the given coordinates. See [GeoSearch](0059-geo-search.md) for more information.
 
-##### 3.1.2.2. Array Syntax
-
-The array syntax is an alternative way to combine different filters with `OR` and `AND` operators.
-
-- Elements in the outer array are connected by `AND` operators
-- Elements in the inner arrays are connected by `OR` operators
-
-Example:
-```json
-{
-    "filter": [["genres = Comedy", "genres = Romance"], "director = 'Mati Diop'"]
-}
-```
-is equivalent to:
-```json
-{
-    "filter": "(genres = Comedy OR genres = Romance) AND (director = 'Mati Diop')"
-}
-```
-
-###### 3.1.2.1.13 Is Empty
+###### 3.1.2.1.13 IS EMPTY
 
 The `IS EMPTY` operator selects the documents for which the filterable attribute exists and is empty. If the attribute doesn't exists then it is not empty and the document will not be returned. It is a postfix operator that takes an attribute name as argument.
 
@@ -390,6 +370,11 @@ attribute IS NOT EMPTY
 NOT attribute IS EMPTY
 ```
 Both forms are equivalent. They select the documents for which the attribute is not empty.
+
+Here is the list of JSON values that are considered empty:
+ - `""`
+ - `[]`
+ - `{}`
 
 For example, with the documents:
 ```json
@@ -415,7 +400,7 @@ For example, with the documents:
 ```
 Then the filter `colour IS EMPTY` selects the document ids `[0,2,3]` while the filter `colour IS NOT EMPTY` or `NOT colour IS EMPTY` selects the document ids `[1,4]`.
 
-###### 3.1.2.1.13 Is Null
+###### 3.1.2.1.13 IS NULL
 
 The `IS NULL` operator selects the documents for which the filterable attribute exists and is `null`. If the attribute doesn't exists then it is not `null` and the document will not be returned. It is a postfix operator that takes an attribute name as argument.
 
@@ -449,6 +434,27 @@ For example, with the documents:
 }]
 ```
 Then the filter `colour IS NULL` selects the document ids `[1]` while the filter `colour IS NOT NULL` or `NOT colour IS NULL` selects the document ids `[0,2,3,4]`.
+
+
+##### 3.1.2.2. Array Syntax
+
+The array syntax is an alternative way to combine different filters with `OR` and `AND` operators.
+
+- Elements in the outer array are connected by `AND` operators
+- Elements in the inner arrays are connected by `OR` operators
+
+Example:
+```json
+{
+    "filter": [["genres = Comedy", "genres = Romance"], "director = 'Mati Diop'"]
+}
+```
+is equivalent to:
+```json
+{
+    "filter": "(genres = Comedy OR genres = Romance) AND (director = 'Mati Diop')"
+}
+```
 
 #### 3.1.3. `sort`
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -159,12 +159,12 @@ The grammar for the value of a filterable attribute is the same as the grammar f
 - In:
     * `attribute IN[value, value, etc.]`
     * `attribute NOT IN[value, value, etc.]`
-- IS NULL:
-    * `attribute IS NULL`
-    * `attribute IS NOT NULL`
 - IS EMPTY:
     * `attribute IS EMPTY`
     * `attribute IS NOT EMPTY`
+- IS NULL:
+    * `attribute IS NULL`
+    * `attribute IS NOT NULL`
 - AND: `filter AND filter`
 - OR: `filter OR filter`
 - NOT: `NOT filter`
@@ -414,7 +414,41 @@ For example, with the documents:
 }]
 ```
 Then the filter `colour IS EMPTY` selects the document ids `[0,2,3]` while the filter `colour IS NOT EMPTY` or `NOT colour IS EMPTY` selects the document ids `[1,4]`.
+
+###### 3.1.2.1.13 Is Null
+
+The `IS NULL` operator selects the documents for which the filterable attribute exists and is `null`. If the attribute doesn't exists then it is not `null` and the document will not be returned. It is a postfix operator that takes an attribute name as argument.
+
+The negated form of `IS NULL` can be written in two ways:
 ```
+attribute IS NOT NULL
+NOT attribute IS NULL
+```
+Both forms are equivalent. They select the documents for which the attribute is not `null`.
+
+For example, with the documents:
+```json
+[{
+    "id": 0,
+    "colour": []
+},
+{
+    "id": 1,
+    "colour": null
+},
+{
+    "id": 2,
+    "colour": ""
+},
+{
+    "id": 3,
+    "colour": {}
+},
+{
+    "id": 4
+}]
+```
+Then the filter `colour IS NULL` selects the document ids `[1]` while the filter `colour IS NOT NULL` or `NOT colour IS NULL` selects the document ids `[0,2,3,4]`.
 
 #### 3.1.3. `sort`
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -156,7 +156,7 @@ The grammar for the value of a filterable attribute is the same as the grammar f
 - Exists:
     * `attribute EXISTS`
     * `attribute NOT EXISTS`
-- In:
+- IN:
     * `attribute IN[value, value, etc.]`
     * `attribute NOT IN[value, value, etc.]`
 - IS EMPTY:


### PR DESCRIPTION
This PR is updating the search API specification and, specifically the filter field. It explains the support of the `IS NULL` and `IS EMPTY` operators. [The original PR](https://github.com/meilisearch/meilisearch/pull/3571) is available on GitHub, and [the original product discussion](https://github.com/meilisearch/product/discussions/539) too!

# Changes

- Explain the `IS EMPTY` operator on the filter field of  the search API
- Explain the `IS NULL` operator on the filter field of  the search API

# Attention To Reviewers

_Explain clearly what reviewers should specifically look for to facilitate the review phase. Also, mention the sections that will not necessarily be taken into account if reviewed._

---

## Misc

- [] ~Update OpenAPI specification file _(if needed; Apply the `OpenApi` label)_~
- [] ~Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_~
