### PR TITLE
Auto deletion of tasks

### DIFF
--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -1010,16 +1010,9 @@ The task types are listed in decreasing order of priority:
 
 ### 2.2. Auto deletion of tasks
 
-Since Meilisearch can't store tasks forever, at some point, it needs to free up some space in its queue.
-The engine will try to delete the 100k last finished tasks upon reaching 1M total tasks stored.
+Since Meilisearch can't store tasks forever, at some point, it needs to free up some space in its queue. The engine will try to delete the 100k last finished tasks upon reaching 1M total tasks stored.
 
-That means after a batch finishes processing and right before processing the following enqueued tasks,
-Meilisearch will check the number of tasks currently written in its queue.
-If this number is more than 1M, the engine will enqueue a new task that automatically deletes
-the last 100k **finished** tasks.
-That means if there are only 2k finished tasks, only these ones will be deleted.
-And if all the tasks in the queue are still enqueued, then nothing will be deleted, and the engine
-will continue to process the next enqueued tasks.
+That means after a batch finishes processing and right before processing the following enqueued tasks, Meilisearch will check the number of tasks currently written in its queue. If this number is more than 1M, the engine will enqueue a new task that automatically deletes the last 100k **finished** tasks. That means if there are only 2k finished tasks, only these ones will be deleted. And if all the tasks in the queue are still enqueued, then nothing will be deleted, and the engine will continue to process the next enqueued tasks.
 
 ## 3. Future Possibilities
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -4,7 +4,7 @@
 
 ### I. Summary
 
-This specification describes the behaviour of the task queue and the API endpoints for handling asynchronous operations.
+This specification describes the behavior of the task queue and the API endpoints for handling asynchronous operations.
 
 ### II. Motivation
 

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -4,7 +4,7 @@
 
 ### I. Summary
 
-This specification describes the API endpoints for handling asynchronous tasks.
+This specification describes the behaviour of the task queue and the API endpoints for handling asynchronous operations.
 
 ### II. Motivation
 
@@ -1008,10 +1008,22 @@ The task types are listed in decreasing order of priority:
 4. `dumpCreation`
 5. All other task types with by their enqueued at order.
 
+### 2.2. Auto deletion of tasks
+
+Since Meilisearch can't store tasks forever, at some point, it needs to free up some space in its queue.
+The engine will try to delete the 100k last finished tasks upon reaching 1M total tasks stored.
+
+That means after a batch finishes processing and right before processing the following enqueued tasks,
+Meilisearch will check the number of tasks currently written in its queue.
+If this number is more than 1M, the engine will enqueue a new task that automatically deletes
+the last 100k **finished** tasks.
+That means if there are only 2k finished tasks, only these ones will be deleted.
+And if all the tasks in the queue are still enqueued, then nothing will be deleted, and the engine
+will continue to process the next enqueued tasks.
+
 ## 3. Future Possibilities
 
 - Use Hateoas capability to give direct access to a `task` resource.
 - Add dedicated task type names modifying a sub-setting. e.g. `SearchableAttributesUpdate`.
-- Add an archived state for old `tasks`.
 - Add the `API Key` identity that added a `task`.
 - Make dump import visible as a task.


### PR DESCRIPTION
# Summary

Specify the auto-deletion of tasks that was introduced in meilisearch v1.2

Associated issue: https://github.com/meilisearch/meilisearch/issues/3622
Implemented in: https://github.com/meilisearch/meilisearch/pull/3693
