### PR TITLE
Update `payload_too_large` error `message`

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1208,7 +1208,7 @@ components:
           examples:
             Payload Too Large:
               value:
-                message: The provided payload reached the size limit.
+                message: The provided payload reached the size limit. The maximum accepted payload size is 20.00 MiB.
                 code: payload_too_large
                 type: invalid_request
                 link: 'https://docs.meilisearch.com/errors#payload_too_large'

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1829,7 +1829,7 @@ HTTP Code: `413 Payload Too Large`
 
 ```json
 {
-    "message": "The provided payload reached the size limit.",
+    "message": "The provided payload reached the size limit. The maximum accepted payload size is :playloadSizeLimit.",
     "code": "payload_too_large",
     "type": "invalid_request",
     "link": "https://docs.meilisearch.com/errors#payload_too_large"


### PR DESCRIPTION
# Summary

Update payload_size_too_large error related to https://github.com/meilisearch/meilisearch/pull/3739

---

# Changes

```diff
{
-    "message": "The provided payload reached the size limit.",
+    "message": "The provided payload reached the size limit. The maximum accepted payload size is :playloadSizeLimit.",
    "code": "payload_too_large",
    "type": "invalid_request",
    "link": "https://docs.meilisearch.com/errors#payload_too_large"
}
```
