### PR TITLE
Vector Search - `EXPERIMENTAL`

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -669,6 +669,11 @@ components:
           description: Query string.
           default: '""'
           example: '"Back to the future"'
+        vector:
+          type: array
+          description: Query vector.
+          default: 'null'
+          example: '[0.8, 0.145, 0.26, 0.3]'
         attributesToRetrieve:
           type: array
           description: 'Array of attributes whose fields will be present in the returned documents. Defaults to the [displayedAttributes list](https://docs.meilisearch.com/reference/features/settings.html#displayed-attributes) which contains by default all attributes found in the documents.'
@@ -1680,6 +1685,8 @@ paths:
 
         > info
         > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
+        >
+        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outter array.
       tags:
         - Documents
       security:
@@ -1734,6 +1741,8 @@ paths:
 
         > info
         > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
+        >
+        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outter array.
       tags:
         - Documents
       security:

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1742,7 +1742,7 @@ paths:
         > info
         > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
         >
-        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outter array.
+        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outer array.
       tags:
         - Documents
       security:

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1686,7 +1686,7 @@ paths:
         > info
         > Use the reserved `_geo` object to add geo coordinates to a document. `_geo` is an object made of `lat` and `lng` field.
         >
-        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outter array.
+        > Use the reserved `_vectors` arrays of floats to add embeddings to a document. `_vectors` is an array of floats or multiple arrays of floats in an outer array.
       tags:
         - Documents
       security:

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -122,7 +122,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filter.with_geoBoundingBox`            | `true` if the filter rule `_geoBoundingBox` was used in this batch, otherwise `false`| false | `Documents Searched POST`, `Documents Searched GET` |
 | `filter.most_used_syntax`               | Most used filter syntax among all requests containing the `filter` parameter in this batch | string | `Documents Searched POST`, `Documents Searched GET` |
 | `q.max_terms_number`                    | Highest number of terms given for the `q` parameter in this batch | 5 | `Documents Searched POST`, `Documents Searched GET` |
-| `vector.max_vector_size`                | Highest number of dimensions given for the `vector` parameter in this batch | 1536 | `Documents Searched POST`, `Documents Searched GET` |
+| `vector.max_vector_size`                | Highest number of dimensions given for the `vector` parameter in this batch | 1536 | `Documents Searched POST`, `Documents Searched GET`, `Documents Searched by Multi-Search POST` |
 | `pagination.max_limit`                  | Highest value given for the `limit` parameter in this batch | 60 | `Documents Searched POST`, `Documents Searched GET`, `Documents Fetched GET`, `Documents Fetched POST` |
 | `pagination.max_offset`                 | Highest value given for the `offset` parameter in this batch | 1000 | `Documents Searched POST`, `Documents Searched GET`, `Documents Fetched GET`, `Documents Fetched POST` |
 | `pagination.most_used_navigation`       | Most used search results navigation among all search requests in this batch. `estimated` / `exhaustive` | `estimated` | `Documents Searched POST`, `Documents Searched GET` |
@@ -269,7 +269,6 @@ This property allows us to gather essential information to better understand on 
 | filter.avg_criteria_number | The average number of filter criteria among all the requests containing the `filter` parameter in the aggregated event. `"filter": []` equals to `0` while not sending `filter` does not influence the average in the aggregated event. | `4` |
 | filter.most_used_syntax | The most used filter syntax among all the requests containing the requests containing the `filter` parameter in the aggregated event. `string` / `array` / `mixed` | `mixed` |
 | q.max_terms_number | The maximum number of terms for the `q` parameter among all requests in the aggregated event. | `5` |
-| vector.max_vector_size | The maximum number of dimensions for the `vector` parameter among all requests in the aggregated event. | `1536` |
 | vector.max_vector_size | The maximum number of dimensions for the `vector` parameter among all requests in the aggregated event. | `1536` |
 | pagination.max_limit | The maximum limit encountered among all requests in the aggregated event. | `20` |
 | pagination.max_offset | The maximum offset encountered among all requests in the aggregated event. | `1000` |

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -122,6 +122,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `filter.with_geoBoundingBox`            | `true` if the filter rule `_geoBoundingBox` was used in this batch, otherwise `false`| false | `Documents Searched POST`, `Documents Searched GET` |
 | `filter.most_used_syntax`               | Most used filter syntax among all requests containing the `filter` parameter in this batch | string | `Documents Searched POST`, `Documents Searched GET` |
 | `q.max_terms_number`                    | Highest number of terms given for the `q` parameter in this batch | 5 | `Documents Searched POST`, `Documents Searched GET` |
+| `vector.max_vector_size`                | Highest number of dimensions given for the `vector` parameter in this batch | 1536 | `Documents Searched POST`, `Documents Searched GET` |
 | `pagination.max_limit`                  | Highest value given for the `limit` parameter in this batch | 60 | `Documents Searched POST`, `Documents Searched GET`, `Documents Fetched GET`, `Documents Fetched POST` |
 | `pagination.max_offset`                 | Highest value given for the `offset` parameter in this batch | 1000 | `Documents Searched POST`, `Documents Searched GET`, `Documents Fetched GET`, `Documents Fetched POST` |
 | `pagination.most_used_navigation`       | Most used search results navigation among all search requests in this batch. `estimated` / `exhaustive` | `estimated` | `Documents Searched POST`, `Documents Searched GET` |
@@ -268,6 +269,8 @@ This property allows us to gather essential information to better understand on 
 | filter.avg_criteria_number | The average number of filter criteria among all the requests containing the `filter` parameter in the aggregated event. `"filter": []` equals to `0` while not sending `filter` does not influence the average in the aggregated event. | `4` |
 | filter.most_used_syntax | The most used filter syntax among all the requests containing the requests containing the `filter` parameter in the aggregated event. `string` / `array` / `mixed` | `mixed` |
 | q.max_terms_number | The maximum number of terms for the `q` parameter among all requests in the aggregated event. | `5` |
+| vector.max_vector_size | The maximum number of dimensions for the `vector` parameter among all requests in the aggregated event. | `1536` |
+| vector.max_vector_size | The maximum number of dimensions for the `vector` parameter among all requests in the aggregated event. | `1536` |
 | pagination.max_limit | The maximum limit encountered among all requests in the aggregated event. | `20` |
 | pagination.max_offset | The maximum offset encountered among all requests in the aggregated event. | `1000` |
 | pagination.most_used_navigation | Most used search results navigation among all requests in the aggregated event. `estimated` / `exhaustive` | `estimated` ||

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1480,7 +1480,9 @@ HTTP Code: `400 Bad Request`
 
 ### Context
 
-This error occurs if a value with a different type than `Array of Float` or `null` for `vector` is specified.
+This error occurs for the listed reasons:
+- if a value with a different type than `Array of Float` or `null` for `vector` is specified.
+- if the vector length differs from the documents `_vectors` length.
 
 ### Error Definition
 
@@ -1896,7 +1898,7 @@ These errors occurs when the `_vectors` field of a document payload is not valid
 
 ### Error Definition
 
-#### Variant: `_vectors` field is not an arry of floats.
+#### Variant: `_vectors` field value type is invalid
 
 ```json
 {

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1886,6 +1886,38 @@ These errors occurs when the `_geo` field of a document payload is not valid. Ei
 
 ---
 
+## invalid_document_vectors_field
+
+`Asynchronous`
+
+### Context
+
+These errors occurs when the `_vectors` field of a document payload is not valid. Either due to the type of it or the number of dimensions.
+
+### Error Definition
+
+#### Variant: `_vectors` field is not an arry of floats.
+
+```json
+{
+    "message": "The `_vectors` field in the document with the id: `:documentId` is not an array. Was expecting an array of floats or an array of arrays of floats but instead got `:field`",
+    "code": "invalid_document_vectors_type",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_document_vectors_type"
+}
+```
+
+#### Variant: Number of dimensions is not correct
+
+```json
+{
+    "message": "Invalid vector dimensions: expected: `:expected`, found: `:found`.",
+    ...
+}
+```
+
+---
+
 ## payload_too_large
 
 `Synchronous`

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1474,6 +1474,29 @@ HTTP Code: `400 Bad Request`
 
 ---
 
+## invalid_search_vector
+
+`Synchronous`
+
+### Context
+
+This error occurs if a value with a different type than `Array of Float` or `null` for `vector` is specified.
+
+### Error Definition
+
+HTTP Code: `400 Bad Request`
+
+```json
+{
+    "message": "`:deserr_helper`",
+    "code": "invalid_search_vector",
+    "type": "invalid_request",
+    "link": "https://docs.meilisearch.com/errors#invalid_search_vector"
+}
+```
+
+---
+
 ## invalid_search_offset
 
 `Synchronous`

--- a/text/0061-error-format-and-definitions.md
+++ b/text/0061-error-format-and-definitions.md
@@ -1894,7 +1894,7 @@ These errors occurs when the `_geo` field of a document payload is not valid. Ei
 
 ### Context
 
-These errors occurs when the `_vectors` field of a document payload is not valid. Either due to the type of it or the number of dimensions.
+This error occurs when the `_vectors` field of a document payload is not valid either due to the type of it or the number of dimensions.
 
 ### Error Definition
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -51,6 +51,7 @@ If a master key is used to secure a Meilisearch instance, the auth layer returns
 | [`cropMarker`](#3115-cropmarker)                      | String                   | False    |
 | [`showMatchesPosition`](#3116-showmatchesposition)    | Boolean                  | False    |
 | [`matchingStrategy`](#3117-matchingStrategy)          | String                   | False    |
+| [`vector`](#3118-vector) `EXPERIMENTAL`               | Array of Float           | False    |
 
 
 #### 3.1.1. `q`
@@ -912,22 +913,33 @@ The documents containing ALL the query words (i.e. in the `q` parameter) are ret
 
 Only the documents containing ALL the query words (i.e. in the `q` parameter) are returned by Meilisearch. If Meilisearch doesn't have enough documents to fit the requested `limit`, it returns the documents found without trying to match more documents.
 
+#### 3.1.18. `vector` `EXPERIMENTAL`
+
+- Type: Array of Float
+- Required: False
+- Default: []
+
+Request the nearest documents based on the query vector embedding being given.
+
+//TODO Describes errors
+
 ### 3.2. Search Response Properties
 
-| Field                                           | Type       | Required |
-|-------------------------------------------------|------------|----------|
-| [`hits`](#321-hits)                             | Array[Hit] | True     |
-| [`limit`](#322-limit)                           | Integer    | False    |
-| [`offset`](#323-offset)                         | Integer    | False    |
-| [`estimatedTotalHits`](#324-estimatedTotalHits) | Integer    | False    |
-| [`page`](#325-page)                             | Integer    | False    |
-| [`hitsPerPage`](#326-hitsperpage)               | Integer    | False    |
-| [`totalPages`](#327-totalpages)                 | Integer    | False    |
-| [`totalHits`](#328-totalhits)                   | Integer    | False    |
-| [`facetDistribution`](#329-facetdistribution)   | Object     | False    |
-| [`facetStats`](#3210-facetstats)                | Object     | False    |
-| [`processingTimeMs`](#3211-processingtimems)    | Integer    | True     |
-| [`query`](#3212-query)                          | String     | True     |
+| Field                                           | Type           | Required  |
+|-------------------------------------------------|----------------|-----------|
+| [`hits`](#321-hits)                             | Array[Hit]     | True      |
+| [`limit`](#322-limit)                           | Integer        | False     |
+| [`offset`](#323-offset)                         | Integer        | False     |
+| [`estimatedTotalHits`](#324-estimatedTotalHits) | Integer        | False     |
+| [`page`](#325-page)                             | Integer        | False     |
+| [`hitsPerPage`](#326-hitsperpage)               | Integer        | False     |
+| [`totalPages`](#327-totalpages)                 | Integer        | False     |
+| [`totalHits`](#328-totalhits)                   | Integer        | False     |
+| [`facetDistribution`](#329-facetdistribution)   | Object         | False     |
+| [`facetStats`](#3210-facetstats)                | Object         | False     |
+| [`processingTimeMs`](#3211-processingtimems)    | Integer        | True      |
+| [`query`](#3212-query)                          | String         | True      |
+| [`vector`](#3213-vector) `EXPERIMENTAL`         | Array of Float | False     |
 
 #### 3.2.1. `hits`
 
@@ -944,11 +956,12 @@ A search result can contain special properties. See [3.2.1.1. `hit` Special Prop
 
 ##### 3.2.1.1. `hit` Special Properties
 
-| Field                                        | Type    | Required |
-|----------------------------------------------|---------|----------|
-| [`_geoDistance`](#32111-geodistance)         | Integer | False    |
-| [`_formatted`](#32112-formatted)             | Object  | False    |
-| [`_matchesPosition`](#32113-matchesposition) | Object  | False    |
+| Field                                                             | Type    | Required |
+|-------------------------------------------------------------------|---------|----------|
+| [`_geoDistance`](#32111-geodistance)                              | Integer | False    |
+| [`_formatted`](#32112-formatted)                                  | Object  | False    |
+| [`_matchesPosition`](#32113-matchesposition)                      | Object  | False    |
+| [`_semanticSimilarity`](#32114-semanticsimilarity) `EXPERIMENTAL` | Float   | False    |
 
 ###### 3.2.1.1.1. `_geoDistance`
 
@@ -1155,6 +1168,15 @@ The beginning of a matching term within a field is indicated by `start`, and its
 
 > See [3.1.14. `showMatchesPosition`](#3116-showmatchesposition) section.
 
+###### 3.2.1.1.4. `_semanticSimilarity` `EXPERIMENTAL`
+
+- Type: Float
+- Required: False
+
+Contains the semantic similarity score of the document for a vector search when `vector` has been provided. The score is represented as a dot product.
+
+> See [3.1.18 `vector`](#3118-vector-experimental)
+
 #### 3.2.2. `limit`
 
 - Type: Integer
@@ -1270,6 +1292,15 @@ Processing time of the search query in **milliseconds**.
 Query originating the response. Equals to the `q` search parameter.
 
 > See [3.1.1. `q`](#311-q) section.
+
+#### 3.2.13. `vector` `EXPERIMENTAL`
+
+- Type: Array of Float
+- Required: False
+
+Vector query embedding originating the response. Equals to the `vector` search parameter if specified.
+
+> See [3.1.18. `vector`](#3118-vector-experimental)
 
 ## 2. Technical Details
 n/a

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -961,7 +961,7 @@ A search result can contain special properties. See [3.2.1.1. `hit` Special Prop
 | [`_geoDistance`](#32111-geodistance)                              | Integer | False    |
 | [`_formatted`](#32112-formatted)                                  | Object  | False    |
 | [`_matchesPosition`](#32113-matchesposition)                      | Object  | False    |
-| [`_semanticSimilarity`](#32114-semanticsimilarity) `EXPERIMENTAL` | Float   | False    |
+| [`_semanticScore`](#32114-semanticsimilarity) `EXPERIMENTAL` | Float   | False    |
 
 ###### 3.2.1.1.1. `_geoDistance`
 
@@ -1168,7 +1168,7 @@ The beginning of a matching term within a field is indicated by `start`, and its
 
 > See [3.1.14. `showMatchesPosition`](#3116-showmatchesposition) section.
 
-###### 3.2.1.1.4. `_semanticSimilarity` `EXPERIMENTAL`
+###### 3.2.1.1.4. `_semanticScore` `EXPERIMENTAL`
 
 - Type: Float
 - Required: False

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -921,7 +921,8 @@ Only the documents containing ALL the query words (i.e. in the `q` parameter) ar
 
 Request the nearest documents based on the query vector embedding being given.
 
-//TODO Describes errors
+- 🔴 Sending a value with a different type than `Array of Float` or `null` as a value for `vector` returns an [invalid_search_vector](0061-error-format-and-definitions.md#invalid_search_vector) error.
+- 🔴 Sending a value for `vector` whose length differs from the documents `_vectors` length returns an [invalid_search_vector](0061-error-format-and-definitions.md#invalid_search_vector) error.
 
 ### 3.2. Search Response Properties
 
@@ -961,7 +962,7 @@ A search result can contain special properties. See [3.2.1.1. `hit` Special Prop
 | [`_geoDistance`](#32111-geodistance)                              | Integer | False    |
 | [`_formatted`](#32112-formatted)                                  | Object  | False    |
 | [`_matchesPosition`](#32113-matchesposition)                      | Object  | False    |
-| [`_semanticScore`](#32114-semanticsimilarity) `EXPERIMENTAL` | Float   | False    |
+| [`_semanticScore`](#32114-semanticscore) `EXPERIMENTAL` | Float   | False    |
 
 ###### 3.2.1.1.1. `_geoDistance`
 

--- a/text/0118-search-api.md
+++ b/text/0118-search-api.md
@@ -919,7 +919,7 @@ Only the documents containing ALL the query words (i.e. in the `q` parameter) ar
 - Required: False
 - Default: []
 
-Request the nearest documents based on the query vector embedding being given.
+Request the nearest documents based on the query vector embedding given.
 
 - 🔴 Sending a value with a different type than `Array of Float` or `null` as a value for `vector` returns an [invalid_search_vector](0061-error-format-and-definitions.md#invalid_search_vector) error.
 - 🔴 Sending a value for `vector` whose length differs from the documents `_vectors` length returns an [invalid_search_vector](0061-error-format-and-definitions.md#invalid_search_vector) error.

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -268,7 +268,7 @@ While the body of a document can contain any pair of keys and values, Meilisearc
 | Field                                                    | Type                     | Required |
 |----------------------------------------------------------|--------------------------|----------|
 | [`_geo`](#3131-_geo)                                     | String | Object          | False    |
-| [`_vectors`](#3132-_vectors-experimental) `EXPERIMENTAL` | Array[Array of Float]    | False    |
+| [`_vectors`](#3132-_vectors-experimental) `EXPERIMENTAL` | Array of Float | Array[Array of Float]    | False    |
 
 ##### 3.1.3.1. `_geo`
 
@@ -278,10 +278,10 @@ Refer to the [geo search specification](0059-geo-search.md)
 
 ##### 3.1.3.2. `_vectors` `EXPERIMENTAL`
 
-Type: Array[Array of Float]
+Type: Array of Float | Array[Array of Float]
 Required: False
 
-Holds a vectorized representation of a document. It is possible to send several vectorized representations of the same document.
+Holds a vectorized representation of a document. It is possible to send either one or several vectorized representations of the same document.
 
 #### 3.1.4. `POST` - `indexes/:index_uid/documents`
 

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -283,6 +283,8 @@ Required: False
 
 Holds a vectorized representation of a document. It is possible to send either one or several vectorized representations of the same document.
 
+- 🔴 Sending a value with a different type than `Array of Float`, `Array[Array of Float]` or `null` as a value for `_vectors` returns an [invalid_document_vectors_field](0061-error-format-and-definitions.md#invalid_document_vectors_field) error.
+- 🔴 Sending a value for `_vectors` whose length differs from another document `_vectors` field returns an [invalid_document_vectors_field](0061-error-format-and-definitions.md#invalid_document_vectors_field) error.
 #### 3.1.4. `POST` - `indexes/:index_uid/documents`
 
 Add a list of documents or replace them if they already exist.

--- a/text/0124-documents-api.md
+++ b/text/0124-documents-api.md
@@ -261,7 +261,29 @@ A document represented as a JSON object.
 - 🔴 If the requested `document_id` does not exist, the API returns an [document_not_found](0061-error-format-and-definitions.md#document_not_found) error.
 - 🔴 Sending a value with a different type than `String` or `null` for `fields` will return a [invalid_document_fields](0061-error-format-and-definitions.md#invalid_document_fields) error.
 
-#### 3.1.3. `POST` - `indexes/:index_uid/documents`
+#### 3.1.3. Documents Body Special Properties
+
+While the body of a document can contain any pair of keys and values, Meilisearch uses specific key names to leverage some search capabilities such as geo search and vector search.
+
+| Field                                                    | Type                     | Required |
+|----------------------------------------------------------|--------------------------|----------|
+| [`_geo`](#3131-_geo)                                     | String | Object          | False    |
+| [`_vectors`](#3132-_vectors-experimental) `EXPERIMENTAL` | Array[Array of Float]    | False    |
+
+##### 3.1.3.1. `_geo`
+
+Holds latitude and longitude geo coordinates for a document.
+
+Refer to the [geo search specification](0059-geo-search.md)
+
+##### 3.1.3.2. `_vectors` `EXPERIMENTAL`
+
+Type: Array[Array of Float]
+Required: False
+
+Holds a vectorized representation of a document. It is possible to send several vectorized representations of the same document.
+
+#### 3.1.4. `POST` - `indexes/:index_uid/documents`
 
 Add a list of documents or replace them if they already exist.
 
@@ -277,100 +299,26 @@ This endpoint accepts various content-type:
 - [`text/csv`](0028-indexing-csv.md)
 - [`application/x-ndjson`](0029-indexing-ndjson.md)
 
-##### 3.1.3.1. Path Parameters
-
-| Field                    | Type                     | Required |
-|--------------------------|--------------------------|----------|
-| `index_uid`              | String                   | True     |
-
-###### 3.1.3.1.1 `index_uid`
-
-- Type: String
-- Required: True
-
-Unique identifier of an index.
-
-##### 3.1.3.2. Request Payload Definition
-
-| Field                    | Type                     | Required |
-|--------------------------|--------------------------|----------|
-| `primaryKey`             | String                   | False    |
-
-###### 3.1.3.2.1 `primaryKey`
-
-- Type: String
-- Required: False
-- Default: `null`
-
-Allows to bypass the auto-inference mechanism of the document identifiers.
-
-By default, the `primaryKey` will be chosen by the auto-inference mechanism by the engine when a first document is indexed.
-
-Specifying this field tells the engine to use the document attribute specified in `primaryKey` and bypasses this mechanism.
-
-When the index is empty, it is possible to modify the `primaryKey`.
-
-If the index is not empty, the query parameter `primaryKey` is ignored.
-
-##### 3.1.3.3. Response Definition
-
-When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
-
-See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
-
-##### 3.1.3.4. Errors
-
-- 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
-- 🔴 Sending an empty Content-Type returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
-- 🔴 Sending a different Content-Type than `application/json`, `text/csv`, or `application/x-ndjson` returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
-- 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
-- 🔴 Sending an invalid payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
-- 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
-- 🔴 Sending a value with a different type than `String` or `null` for the `primaryKey` parameter will return a [invalid_index_primary_key](0061-error-format-and-definitions.md#invalid_index_primary_key) error.
-
-###### 3.1.3.4.1. Async Errors
-
-- 🔴 When Meilisearch is secured, if the API Key do not have the `indexes.create` action defined, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error in the related asynchronous `task` resource. See [3.2.2.2. Response Definition](#3222-response-definition).
-- 🔴 When updating the `primaryKey`, if the previous `primaryKey` value has already been used for a document, the API returns an [index_primary_key_already_exists](0061-error-format-and-definitions.md#index_primary_key_already_exists) error.
-
-##### 3.1.3.5. Lazy Index Creation
-
-If the requested `index_uid` does not exist, and the authorization layer allows it (See [3.1.3.4.1. Async Errors](#31341-async-errors)), Meilisearch will create the index when the related asynchronous task resource is executed. See [3.1.3.3. Response Definition](#3133-response-definition).
-
-#### 3.1.4. `PUT` - `indexes/:index_uid/documents`
-
-Add a list of documents or update them if they already exist.
-
-If the provided index does not exist, it will be created. See [3.1.4.5. Lazy Index Creation](#3145-lazy-index-creation)
-
-If an already existing document (same identifier) is set, the old document will be only partially updated according to the fields of the new document. Thus, any fields not present in the new document are kept and remain unchanged.
-
-This endpoint accepts various content-type:
-
-- [`application/json`](0135-indexing-json.md)
-- [`text/csv`](0028-indexing-csv.md)
-- [`application/x-ndjson`](0029-indexing-ndjson.md)
-
 ##### 3.1.4.1. Path Parameters
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `index_uid`              | String                   | True     |
 
-###### 3.1.4.1.1. `index_uid`
+###### 3.1.4.1.1 `index_uid`
 
 - Type: String
 - Required: True
 
 Unique identifier of an index.
 
-##### 3.1.4.2. Query Parameters Definition
+##### 3.1.4.2. Request Payload Definition
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `primaryKey`             | String                   | False    |
 
-###### 3.1.4.2.1. `primaryKey`
+###### 3.1.4.2.1 `primaryKey`
 
 - Type: String
 - Required: False
@@ -409,17 +357,27 @@ See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-t
 
 ##### 3.1.4.5. Lazy Index Creation
 
-If the requested `index_uid` does not exist, and the authorization layer allows it (See [3.1.4.4.1. Async Errors](#31441-async-errors)), Meilisearch will create the index when the related asynchronous task resource is executed. See [3.1.4.3. Response Definition](#3143-response-definition).
+If the requested `index_uid` does not exist, and the authorization layer allows it (See [3.1.3.4.1. Async Errors](#31341-async-errors)), Meilisearch will create the index when the related asynchronous task resource is executed. See [3.1.3.3. Response Definition](#3133-response-definition).
 
-#### 3.1.5. `DELETE` - `indexes/:index_uid/documents`
+#### 3.1.5. `PUT` - `indexes/:index_uid/documents`
 
-Delete all documents in the specified index.
+Add a list of documents or update them if they already exist.
+
+If the provided index does not exist, it will be created. See [3.1.4.5. Lazy Index Creation](#3145-lazy-index-creation)
+
+If an already existing document (same identifier) is set, the old document will be only partially updated according to the fields of the new document. Thus, any fields not present in the new document are kept and remain unchanged.
+
+This endpoint accepts various content-type:
+
+- [`application/json`](0135-indexing-json.md)
+- [`text/csv`](0028-indexing-csv.md)
+- [`application/x-ndjson`](0029-indexing-ndjson.md)
 
 ##### 3.1.5.1. Path Parameters
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
-| `index_uid`              | String                   | true     |
+| `index_uid`              | String                   | True     |
 
 ###### 3.1.5.1.1. `index_uid`
 
@@ -428,8 +386,27 @@ Delete all documents in the specified index.
 
 Unique identifier of an index.
 
-##### 3.1.5.2. Request Payload Definition
-N/A
+##### 3.1.5.2. Query Parameters Definition
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `primaryKey`             | String                   | False    |
+
+###### 3.1.5.2.1. `primaryKey`
+
+- Type: String
+- Required: False
+- Default: `null`
+
+Allows to bypass the auto-inference mechanism of the document identifiers.
+
+By default, the `primaryKey` will be chosen by the auto-inference mechanism by the engine when a first document is indexed.
+
+Specifying this field tells the engine to use the document attribute specified in `primaryKey` and bypasses this mechanism.
+
+When the index is empty, it is possible to modify the `primaryKey`.
+
+If the index is not empty, the query parameter `primaryKey` is ignored.
 
 ##### 3.1.5.3. Response Definition
 
@@ -439,22 +416,32 @@ See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-t
 
 ##### 3.1.5.4. Errors
 
+- 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
+- 🔴 Sending an empty Content-Type returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending a different Content-Type than `application/json`, `text/csv`, or `application/x-ndjson` returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
+- 🔴 Sending an invalid payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
 - 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
+- 🔴 Sending a value with a different type than `String` or `null` for the `primaryKey` parameter will return a [invalid_index_primary_key](0061-error-format-and-definitions.md#invalid_index_primary_key) error.
 
 ###### 3.1.5.4.1. Async Errors
 
-- 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
+- 🔴 When Meilisearch is secured, if the API Key do not have the `indexes.create` action defined, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error in the related asynchronous `task` resource. See [3.2.2.2. Response Definition](#3222-response-definition).
+- 🔴 When updating the `primaryKey`, if the previous `primaryKey` value has already been used for a document, the API returns an [index_primary_key_already_exists](0061-error-format-and-definitions.md#index_primary_key_already_exists) error.
 
-#### 3.1.6. `DELETE` - `indexes/:index_uid/documents/:document_id`
+##### 3.1.5.5. Lazy Index Creation
 
-Delete one document based on its unique id.
+If the requested `index_uid` does not exist, and the authorization layer allows it (See [3.1.4.4.1. Async Errors](#31441-async-errors)), Meilisearch will create the index when the related asynchronous task resource is executed. See [3.1.4.3. Response Definition](#3143-response-definition).
+
+#### 3.1.6. `DELETE` - `indexes/:index_uid/documents`
+
+Delete all documents in the specified index.
 
 ##### 3.1.6.1. Path Parameters
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
-| `index_uid`              | String                   | True     |
-| `document_id`            | String                   | True     |
+| `index_uid`              | String                   | true     |
 
 ###### 3.1.6.1.1. `index_uid`
 
@@ -462,13 +449,6 @@ Delete one document based on its unique id.
 - Required: True
 
 Unique identifier of an index.
-
-###### 3.1.6.1.2. `document_id`
-
-- Type: Integer
-- Required: True
-
-Unique identifier of a document.
 
 ##### 3.1.6.2. Request Payload Definition
 N/A
@@ -487,15 +467,16 @@ See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-t
 
 - 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
 
-#### 3.1.7. `POST` - `indexes/:index_uid/documents/delete-batch`
+#### 3.1.7. `DELETE` - `indexes/:index_uid/documents/:document_id`
 
-Delete a selection of documents based on array of document id's.
+Delete one document based on its unique id.
 
 ##### 3.1.7.1. Path Parameters
 
 | Field                    | Type                     | Required |
 |--------------------------|--------------------------|----------|
 | `index_uid`              | String                   | True     |
+| `document_id`            | String                   | True     |
 
 ###### 3.1.7.1.1. `index_uid`
 
@@ -504,42 +485,33 @@ Delete a selection of documents based on array of document id's.
 
 Unique identifier of an index.
 
-##### 3.1.7.2 Request Payload Definition
+###### 3.1.7.1.2. `document_id`
 
-An array of document ids to delete.
-
-- Type: Array
+- Type: Integer
 - Required: True
 
-e.g.
+Unique identifier of a document.
 
-```json
-[122, 1194, 2501]
-```
+##### 3.1.7.2. Request Payload Definition
+N/A
 
 ##### 3.1.7.3. Response Definition
 
-When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task with the type `documentDeletion`.
+When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
 
 See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
 
 ##### 3.1.7.4. Errors
 
-- 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
-- 🔴 Sending an empty Content-Type returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
-- 🔴 Sending a different Content-Type than `application/json` returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
-- 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
-- 🔴 Sending an invalid payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
 - 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
-- 🔴 Sending a value with a different type than `Array` for the body request will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
-###### 3.1.7.4.1 Async Errors
+###### 3.1.7.4.1. Async Errors
 
 - 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
 
-#### 3.1.8. `POST` - `indexes/:index_uid/documents/delete`
+#### 3.1.8. `POST` - `indexes/:index_uid/documents/delete-batch`
 
-Delete a selection of documents based on a filter.
+Delete a selection of documents based on array of document id's.
 
 ##### 3.1.8.1. Path Parameters
 
@@ -556,17 +528,15 @@ Unique identifier of an index.
 
 ##### 3.1.8.2 Request Payload Definition
 
-A filter.
+An array of document ids to delete.
 
-- Type: String or array of array of strings
+- Type: Array
 - Required: True
 
 e.g.
 
 ```json
-{
-  "filter": "doggo = 'bernese mountain'"
-}
+[122, 1194, 2501]
 ```
 
 ##### 3.1.8.3. Response Definition
@@ -583,18 +553,70 @@ See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-t
 - 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
 - 🔴 Sending an invalid payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
 - 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
-- 🔴 Sending a value without a filter will return a [missing_document_filter](0061-error-format-and-definitions.md#missing_document_filter) error.
-- 🔴 Sending a value with an invalid or empty filter will return an [invalid_document_filter](0061-error-format-and-definitions.md#invalid_document_filter) error.
+- 🔴 Sending a value with a different type than `Array` for the body request will return a [bad_request](0061-error-format-and-definitions.md#bad_request) error.
 
 ###### 3.1.8.4.1 Async Errors
 
 - 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
 
-#### 3.1.9. General Errors
+#### 3.1.9. `POST` - `indexes/:index_uid/documents/delete`
+
+Delete a selection of documents based on a filter.
+
+##### 3.1.9.1. Path Parameters
+
+| Field                    | Type                     | Required |
+|--------------------------|--------------------------|----------|
+| `index_uid`              | String                   | True     |
+
+###### 3.1.9.1.1. `index_uid`
+
+- Type: String
+- Required: True
+
+Unique identifier of an index.
+
+##### 3.1.9.2 Request Payload Definition
+
+A filter.
+
+- Type: String or array of array of strings
+- Required: True
+
+e.g.
+
+```json
+{
+  "filter": "doggo = 'bernese mountain'"
+}
+```
+
+##### 3.1.9.3. Response Definition
+
+When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task with the type `documentDeletion`.
+
+See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
+
+##### 3.1.9.4. Errors
+
+- 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
+- 🔴 Sending an empty Content-Type returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending a different Content-Type than `application/json` returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
+- 🔴 Sending an invalid payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
+- 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
+- 🔴 Sending a value without a filter will return a [missing_document_filter](0061-error-format-and-definitions.md#missing_document_filter) error.
+- 🔴 Sending a value with an invalid or empty filter will return an [invalid_document_filter](0061-error-format-and-definitions.md#invalid_document_filter) error.
+
+###### 3.1.9.4.1 Async Errors
+
+- 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
+
+#### 3.1.10. General Errors
 
 These errors apply to all endpoints described here.
 
-##### 3.1.9.1 Auth Errors
+##### 3.1.10.1 Auth Errors
 
 The auth layer can return the following errors if Meilisearch is secured (a master-key is defined).
 


### PR DESCRIPTION
🤖  [API Diff](https://github.com/meilisearch/specifications/pull/248#issuecomment-1609060852)

---

# Summary

Describes the experimental vector search related properties and capabilities

---

# Changes

- Introduces `vector` and `_semanticScore` properties on `search-api.md`
- Introduces the special properties `_vectors` for a document body
- Describes related errors
    - `invalid_search_vector`
    - `invalid_document_vectors_field`
- Add the experimental properties on open-api.yaml
- Describes added telemetry


# Out Of Scope

N/A

---

# Attention To Reviewers

N/A

---

## Misc

- [x] Update OpenAPI specification file
- [x] Update telemetry datapoints _(if needed; Apply the `Telemetry` label)_
