### PR TITLE
Tasks route total

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -3780,6 +3780,8 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/task'
+                  total:
+                    $ref: '#/components/schemas/total'
                   limit:
                     $ref: '#/components/schemas/limit'
                   from:
@@ -3788,6 +3790,7 @@ paths:
                     $ref: '#/components/schemas/next'
                 required:
                   - results
+                  - total
                   - limit
                   - from
                   - next
@@ -3830,6 +3833,7 @@ paths:
                     next: null
       operationId: tasks.list
       parameters:
+        - $ref: '#/components/parameters/total'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/from'
         - $ref: '#/components/parameters/taskFilterUids'

--- a/text/0060-tasks-api.md
+++ b/text/0060-tasks-api.md
@@ -564,6 +564,7 @@ The main drawback of this type of pagination is that it does not navigate within
 
 | field | type | description                          |
 |-------|------|--------------------------------------|
+| total | integer  | The total number of tasks matching the filter/query |
 | limit | integer  | Default `20`. |
 | from | integer | The first task uid returned |
 | next | integer - nullable  | Represents the value to send in `from` to fetch the next slice of the results. The first item for the next slice starts at this exact number. When the returned value is null, it means that all the data have been browsed in the given order. |
@@ -602,6 +603,7 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
             ...,
         }
     ],
+    "total": 1351,
     "limit": 20,
     "from": 1350,
     "next": 1329
@@ -629,6 +631,7 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
             ...,
         }
     ],
+    "total": 1330,
     "limit": 50,
     "from": 1329,
     "next": 1278
@@ -656,6 +659,7 @@ This part demonstrates keyset paging in action on `/tasks`. The items `uid` rema
             ...,
         }
     ],
+    "total": 20,
     "limit": 20,
     "from": 20,
     "next": null


### PR DESCRIPTION
As [we recently added the `total` field on the `/tasks` route](https://github.com/meilisearch/meilisearch/pull/3889) I update the specifications accordingly. The `total` field exposes the total number of tasks matching the given tasks filter/query.