### PR TITLE
Separators settings api

### DIFF
--- a/open-api.yaml
+++ b/open-api.yaml
@@ -490,6 +490,24 @@ components:
         - of
         - the
         - to
+    separatorTokens:
+      type: array
+      description: List of tokens that will be considered as word separators by Meilisearch.
+      items:
+        type: string
+      example:
+        - "&"
+        - "</br>"
+        - "@"
+    nonSeparatorTokens:
+      type: array
+      description: List of tokens that will not be considered as word separators by Meilisearch.
+      items:
+        type: string
+      example:
+        - "#"
+        - "-"
+        - "_"
     sortableAttributes:
       type: array
       description: List of attributes to sort on at search.

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -60,6 +60,8 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | DistinctAttribute Updated | Occurs when distinct attribute setting is updated via `PUT` — `/indexes/:indexUid/settings/distinct-attribute`. |
 | DisplayedAttributes Updated | Occurs when displayed attributes are updated via `PUT` — `/indexes/:indexUid/settings/displayed-attributes`. |
 | StopWords Updated | Occurs when stop words are updated via `PUT` — `/indexes/:indexUid/settings/stop-words`. |
+| separatorTokens Updated | Occurs when separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/separator-tokens`. |
+| nonSeparatorTokens Updated | Occurs when non separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/non-separator-tokens`. |
 | Synonyms Updated | Occurs when synonyms are updated via `PUT` — `/indexes/:indexUid/settings/synonyms`. |
 | Dump Created | Occurs when a dump is created via `POST` - `/dumps`. |
 | Tasks Canceled | Occurs when tasks are requested to be canceled via `POST` - `/tasks/cancel`. |
@@ -161,6 +163,8 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | `displayed_attributes.total`   | Number of displayed attributes. | `3` | `SettingUpdated`, `DisplayedAttributes Updated` |
 | `displayed_attributes.with_wildcard` | `true` if `*` is specified as a displayed attribute, otherwise `false`. | `false` | `SettingUpdated`, `DisplayedAttributes Updated` |
 | `stop_words.total`   | Number of stop words. | `3` | `Settings Updated`, `StopWords Updated` |
+| `separator_tokens.total`   | Number of separator tokens. | `3` | `Settings Updated`, `SeparatorTokens Updated` |
+| `non_separator_tokens.total`   | Number of non separator tokens. | `3` | `Settings Updated`, `NonSeparatorTokens Updated` |
 | `synonyms.total`   | Number of synonyms. | `3` | `Settings Updated`, `Synonyms Updated` |
 | `per_task_uid`                          | `true` if an uid is used to fetch a particular task resource, otherwise `false` | true | `Tasks Seen` |
 | `filtered_by_uid`                       | `true` if tasks are filtered by the `uids` query parameter, otherwise `false` | false | `Tasks Seen`, `Tasks Canceled`, `Tasks Deleted` |
@@ -453,6 +457,8 @@ This property allows us to gather essential information to better understand on 
 | displayed_attributes.total   | Number of displayed attributes. | `3` |
 | displayed_attributes.with_wildcard | `true` if `*` is specified as a displayed attribute, otherwise `false`. | `false` |
 | stop_words.total   | Number of stop words. | `3` |
+| separator_tokens.total   | Number of separator tokens. | `3` |
+| non_separator_tokens.total   | Number of non separator tokens. | `3` |
 | synonyms.total   | Number of synonyms. | `3` |
 
 ---
@@ -544,6 +550,20 @@ This property allows us to gather essential information to better understand on 
 |---------------|-------------|---------|
 | user_agent    | Represents the user-agent encountered on this call. | `["Meilisearch Ruby (v2.1)", "Ruby (3.0)"]` |
 | stop_words.total   | Number of stop words. | `3` |
+
+## `SeparatorTokens Updated`
+
+| Property name | Description | Example |
+|---------------|-------------|---------|
+| user_agent    | Represents the user-agent encountered on this call. | `["Meilisearch Ruby (v2.1)", "Ruby (3.0)"]` |
+| separator_tokens.total   | Number of separator tokens. | `3` |
+
+## `NonSeparatorTokens Updated`
+
+| Property name | Description | Example |
+|---------------|-------------|---------|
+| user_agent    | Represents the user-agent encountered on this call. | `["Meilisearch Ruby (v2.1)", "Ruby (3.0)"]` |
+| non_separator_tokens.total   | Number of non separator tokens. | `3` |
 
 ## `Synonyms Updated`
 

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -60,7 +60,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | DistinctAttribute Updated | Occurs when distinct attribute setting is updated via `PUT` — `/indexes/:indexUid/settings/distinct-attribute`. |
 | DisplayedAttributes Updated | Occurs when displayed attributes are updated via `PUT` — `/indexes/:indexUid/settings/displayed-attributes`. |
 | StopWords Updated | Occurs when stop words are updated via `PUT` — `/indexes/:indexUid/settings/stop-words`. |
-| separatorTokens Updated | Occurs when separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/separator-tokens`. |
+| SeparatorTokens Updated | Occurs when separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/separator-tokens`. |
 | NonSeparatorTokens Updated | Occurs when non separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/non-separator-tokens`. |
 | Synonyms Updated | Occurs when synonyms are updated via `PUT` — `/indexes/:indexUid/settings/synonyms`. |
 | Dump Created | Occurs when a dump is created via `POST` - `/dumps`. |

--- a/text/0034-telemetry-policies.md
+++ b/text/0034-telemetry-policies.md
@@ -61,7 +61,7 @@ The collected data is sent to [Segment](https://segment.com/). Segment is a plat
 | DisplayedAttributes Updated | Occurs when displayed attributes are updated via `PUT` — `/indexes/:indexUid/settings/displayed-attributes`. |
 | StopWords Updated | Occurs when stop words are updated via `PUT` — `/indexes/:indexUid/settings/stop-words`. |
 | separatorTokens Updated | Occurs when separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/separator-tokens`. |
-| nonSeparatorTokens Updated | Occurs when non separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/non-separator-tokens`. |
+| NonSeparatorTokens Updated | Occurs when non separator tokens are updated via `PUT` — `/indexes/:indexUid/settings/non-separator-tokens`. |
 | Synonyms Updated | Occurs when synonyms are updated via `PUT` — `/indexes/:indexUid/settings/synonyms`. |
 | Dump Created | Occurs when a dump is created via `POST` - `/dumps`. |
 | Tasks Canceled | Occurs when tasks are requested to be canceled via `POST` - `/tasks/cancel`. |

--- a/text/0123-separators-settings-api.md
+++ b/text/0123-separators-settings-api.md
@@ -1,0 +1,164 @@
+# Stop Words Setting API
+
+## 1. Summary
+
+This specification describes the `separatorTokens` and `nonSeparatorTokens` index setting API endpoints.
+
+## 2. Motivation
+N/A
+
+## 3. Functional Specification
+
+### 3.1. Explanations
+
+TBD
+
+#### 3.1.1. Usage Examples
+
+***Request payload `PUT`- `/indexes/articles/settings/separator-tokens`***
+```json
+["|", "/", "&sep"]
+```
+
+***Request payload `PUT`- `/indexes/articles/settings/non-separator-tokens`***
+```json
+["@", "#"]
+```
+
+### 3.2. Global Settings API Endpoints Definition
+
+`separatorTokens` and `nonSeparatorTokens` are sub-resources of `/indexes/:index_uid/settings`.
+
+See [Settings API](0123-settings-api.md).
+
+### 3.3. API Endpoints Definition
+
+Manipulate the `separatorTokens` and `nonSeparatorTokens` settings of a Meilisearch index.
+
+#### 3.3.1. `GET` 
+
+##### 3.3.1.1. `GET` - `indexes/:index_uid/settings/separator-tokens`
+
+Fetch the `separatorTokens` setting of a Meilisearch index.
+
+***Response Definition:***
+- Type: Array of String
+- Default: `[]`
+
+##### 3.3.1.2. `GET` - `indexes/:index_uid/settings/non-separator-tokens`
+
+Fetch the `nonSeparatorTokens` setting of a Meilisearch index.
+
+***Response Definition:***
+- Type: Array of String
+- Default: `[]`
+
+##### 3.3.1.3. Errors
+
+- 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
+- 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error.
+
+#### 3.3.2. `PUT`
+
+##### 3.3.2.1. `PUT` - `indexes/:index_uid/settings/separator-tokens`
+
+Modify the `separatorTokens` setting of a Meilisearch index.
+
+###### 3.3.2.1.1. Request Payload Definition
+
+- Type: Array of String / `null`
+
+Setting `null` is equivalent to using the [3.3.3.1. `DELETE` - `indexes/:index_uid/settings/separator-tokens`](#3331-delete---indexesindexuidsettingsseparator-tokens) API endpoint.
+
+###### 3.3.2.1.2. Response Definition
+
+When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
+
+See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
+
+##### 3.3.2.2. `PUT` - `indexes/:index_uid/settings/non-separator-tokens`
+
+Modify the `nonSeparatorTokens` setting of a Meilisearch index.
+
+###### 3.3.2.2.1. Request Payload Definition
+
+- Type: Array of String / `null`
+
+Setting `null` is equivalent to using the [3.3.3.2. `DELETE` - `indexes/:index_uid/settings/non-separator-tokens`](#3332-delete---indexesindexuidsettingsnon-separator-tokens) API endpoint.
+
+###### 3.3.2.2.2. Response Definition
+
+When the request is successful, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
+
+See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
+
+##### 3.3.2.3. Errors
+
+- 🔴 Omitting Content-Type header returns a [missing_content_type](0061-error-format-and-definitions.md#missing_content_type) error.
+- 🔴 Sending an empty Content-Type returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending a different Content-Type than `application/json` returns an [invalid_content_type](0061-error-format-and-definitions.md#invalid_content_type) error.
+- 🔴 Sending an empty payload returns a [missing_payload](0061-error-format-and-definitions.md#missing_payload) error.
+- 🔴 Sending an invalid JSON payload returns a [malformed_payload](0061-error-format-and-definitions.md#malformed_payload) error.
+- 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
+- 🔴 Sending a request payload value type different of `Array of String`, `[]`,  or `null` returns an [invalid_settings_stop_words](0061-error-format-and-definitions.md#invalid_settings_stop_words) error.
+
+###### 3.3.2.3.1. Async Errors
+
+- 🔴 When Meilisearch is secured, if the API Key do not have the `indexes.create` action defined, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error in the related asynchronous `task` resource. See [3.3.2.2. Response Definition](#3222-response-definition).
+
+> Otherwise, Meilisearch will create the index in a lazy way. See [3.2.2.4. Lazy Index Creation](#3224-lazy-index-creation).
+
+##### 3.3.2.4. Lazy Index Creation
+
+If the requested `index_uid` does not exist, and the authorization layer allows it (See [3.3.2.3.1. Async Errors](#33231-async-errors)), Meilisearch will create the index when the related asynchronous task resource is executed. See [3.3.2.2. Response Definition](#3322-response-definition).
+
+#### 3.3.3. `DELETE`
+##### 3.3.3.1 `DELETE` - `indexes/:index_uid/settings/separator-tokens`
+
+Reset the `separatorTokens` setting of a Meilisearch index to the default value `[]`.
+
+###### 3.3.3.1.1. Response Definition
+
+When the request is in a successful state, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
+
+See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
+
+##### 3.3.3.2 `DELETE` - `indexes/:index_uid/settings/non-separator-tokens`
+
+Reset the `nonSeparatorTokens` setting of a Meilisearch index to the default value `[]`.
+
+###### 3.3.3.2.1. Response Definition
+
+When the request is in a successful state, Meilisearch returns the HTTP code `202 Accepted`. The response's content is the summarized representation of the received asynchronous task.
+
+See [Summarized `task` Object for `202 Accepted`](0060-tasks-api.md#summarized-task-object-for-202-accepted).
+
+##### 3.3.3.3. Errors
+
+- 🔴 Sending an invalid index uid format for the `:index_uid` path parameter returns an [invalid_index_uid](0061-error-format-and-definitions.md#invalid_index_uid) error.
+
+###### 3.3.3.3.1. Asynchronous Index Not Found Error
+
+- 🔴 If the requested `index_uid` does not exist, the API returns an [index_not_found](0061-error-format-and-definitions.md#index_not_found) error in the related async `task` resource. See [3.3.3.1. Response Definition](#3331-response-definition).
+
+#### 3.3.4. General Errors
+
+These errors apply to all endpoints described here.
+
+##### 3.3.4.1 Auth Errors
+
+The auth layer can return the following errors if Meilisearch is secured (a master-key is defined).
+
+- 🔴 Accessing this route without the `Authorization` header returns a [missing_authorization_header](0061-error-format-and-definitions.md#missing_authorization_header) error.
+- 🔴 Accessing this route with a key that does not have permissions (i.e. other than the master-key) returns an [invalid_api_key](0061-error-format-and-definitions.md#invalid_api_key) error.
+
+## 4. Technical Details
+
+### 4.1. Triggering Documents Re-Indexing
+
+Meilisearch favors search speed and makes a trade-off on indexing speed by computing internal data structures to get search results as fast as possible.
+
+Modifying this index setting cause documents to be re-indexed.
+
+## 5. Future Possibilities
+n/a

--- a/text/0123-separators-settings-api.md
+++ b/text/0123-separators-settings-api.md
@@ -1,4 +1,4 @@
-# Stop Words Setting API
+# Separators Setting API
 
 ## 1. Summary
 

--- a/text/0123-separators-settings-api.md
+++ b/text/0123-separators-settings-api.md
@@ -11,7 +11,6 @@ N/A
 
 ### 3.1. Explanations
 
-TBD
 
 #### 3.1.1. Usage Examples
 

--- a/text/0123-settings-api.md
+++ b/text/0123-settings-api.md
@@ -19,6 +19,8 @@ N/A
 | [sortable-attributes](0123-sortable-attributes-setting-api.md)     | `sortableAttributes` sub-resource API endpoints definition   |
 | [ranking-rules](0123-ranking-rules-setting-api.md)                 | `rankingRules` sub-resource API endpoints definition         |
 | [stop-words](0123-stop-words-setting-api.md)                       | `stopWords` sub-resource API endpoints definition            |
+| [separator-tokens](0123-separators-settings-api.md)                | `separatorTokens` sub-resource API endpoints definition      |
+| [non-separator-tokens](0123-separators-settings-api.md)            | `nonSeparatorTokens` sub-resource API endpoints definition   |
 | [synonyms](0123-synonyms-setting-api.md)                           | `synonyms` sub-resource API endpoints definition             |
 | [distinct-attribute](0123-distinct-attribute-setting-api.md)       | `distinctAttribute` sub-resource API endpoints definition    |
 | [typo-tolerance](0117-typo-tolerance-setting-api.md)               | `typoTolerance` sub-resource API endpoints definition        |
@@ -47,6 +49,8 @@ Fetch the settings of a Meilisearch index.
 | `sortableAttributes`     | Array of String         | true     |
 | `rankingRules`           | Array of String         | true     |
 | `stopWords`              | Array of String         | true     |
+| `separatorTokens`        | Array of String         | true     |
+| `nonSeparatorTokens`     | Array of String         | true     |
 | `synonyms`               | Object                  | true     |
 | `distinctAttribute`      | String / `null`         | true     |
 | `typoTolerance`          | Object                  | true     |
@@ -73,6 +77,8 @@ Modify the settings of a Meilisearch index.
 | `sortableAttributes`     | Array of String / `null` | false    |
 | `rankingRules`           | Array of String / `null` | false    |
 | `stopWords`              | Array of String / `null` | false    |
+| `separatorTokens`        | Array of String / `null` | false    |
+| `nonSeparatorTokens`     | Array of String / `null` | false    |
 | `synonyms`               | Object / `null`          | false    |
 | `distinctAttribute`      | String / `null`          | false    |
 | `typoTolerance`          | Object / `null`          | false    |
@@ -157,6 +163,8 @@ Changing any of the following index settings will cause documents to be re-index
 - `sortableAttributes`
 - `distinctAttribute`
 - `stopWords`
+- `separatorTokens`
+- `nonSeparatorTokens`
 
 ## 5. Future Possibilities
 


### PR DESCRIPTION
# Summary

Allow the user to customize the list of separators used by Meilisearch to segment the documents and the queries by providing 2 new settings:
- `separatorTokens`: List of the tokens that should be considered separators
- `nonSeparatorTokens`: List of the tokens that should not be considered separators


# Changes

- add a new dedicated settings spec
- update the global settings spec
- update telemetry spec

## Misc

- [x] Update OpenAPI specification file
- [x] Update telemetry datapoints